### PR TITLE
i4: Allow specification of numerical types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust@i27-float
+  - mrc-ide/dust
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust
+  - mrc-ide/dust@i27-float
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.0.1
+Version: 0.0.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),
@@ -17,7 +17,7 @@ Language: en-GB
 URL: https://github.com/mrc-ide/odin.dust
 BugReports: https://github.com/mrc-ide/odin.dust/issues
 Imports:
-    dust,
+    dust (>= 0.0.2),
     odin
 Suggests:
     Rcpp,

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -1,4 +1,4 @@
-generate_dust <- function(ir, options) {
+generate_dust <- function(ir, options, real_t = NULL, int_t = NULL) {
   dat <- odin::odin_ir_deserialise(ir)
 
   if (!dat$features$discrete) {
@@ -14,7 +14,7 @@ generate_dust <- function(ir, options) {
          paste(squote(unsupported), collapse = ", "))
   }
 
-  dat$meta$dust <- generate_dust_meta()
+  dat$meta$dust <- generate_dust_meta(real_t, int_t)
 
   rewrite <- function(x) {
     generate_dust_sexp(x, dat$data, dat$meta)
@@ -39,8 +39,10 @@ generate_dust <- function(ir, options) {
 }
 
 
-generate_dust_meta <- function() {
-  list(rng = "rng")
+generate_dust_meta <- function(real_t, int_t) {
+  list(rng = "rng",
+       real_t = real_t %||% "double",
+       int_t = int_t %||% "int")
 }
 
 
@@ -80,8 +82,8 @@ generate_dust_core_struct <- function(dat) {
   i <- vcapply(dat$data$elements, "[[", "location") == "internal"
   els <- vcapply(unname(dat$data$elements[i]), struct_element)
 
-  c("typedef int int_t;",
-    "typedef double real_t;",
+  c(sprintf("typedef %s int_t;", dat$meta$dust$int_t),
+    sprintf("typedef %s real_t;", dat$meta$dust$real_t),
     "struct init_t {",
     paste0("  ", els),
     "};")

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -80,7 +80,9 @@ generate_dust_core_struct <- function(dat) {
   i <- vcapply(dat$data$elements, "[[", "location") == "internal"
   els <- vcapply(unname(dat$data$elements[i]), struct_element)
 
-  c("struct init_t {",
+  c("typedef int int_t;",
+    "typedef double float_t;",
+    "struct init_t {",
     paste0("  ", els),
     "};")
 }
@@ -145,7 +147,7 @@ generate_dust_core_update <- function(eqs, dat, rewrite) {
   body <- dust_flatten_eqs(c(unpack, eqs[equations]))
   args <- c("size_t" = dat$meta$time,
             "const std::vector<double>&" = dat$meta$state,
-            "dust::RNG&" = dat$meta$dust$rng,
+            "dust::RNG<double, int>&" = dat$meta$dust$rng,
             "std::vector<double>&" = dat$meta$result)
 
   cpp_function("void", "update", args, body)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -40,9 +40,7 @@ generate_dust <- function(ir, options) {
 
 
 generate_dust_meta <- function() {
-  list(rng = "rng",
-       int_t = "int_t",
-       float_t = "float_t")
+  list(rng = "rng")
 }
 
 
@@ -83,7 +81,7 @@ generate_dust_core_struct <- function(dat) {
   els <- vcapply(unname(dat$data$elements[i]), struct_element)
 
   c("typedef int int_t;",
-    "typedef double float_t;",
+    "typedef double real_t;",
     "struct init_t {",
     paste0("  ", els),
     "};")
@@ -129,13 +127,12 @@ generate_dust_core_initial <- function(dat, rewrite) {
   initial <- dust_flatten_eqs(lapply(dat$data$variable$contents, set_initial))
 
   args <- c("size_t" = dat$meta$time)
-  body <- c(sprintf("std::vector<float_t> %s(%s);",
+  body <- c(sprintf("std::vector<real_t> %s(%s);",
                     dat$meta$state, rewrite(dat$data$variable$length)),
             dust_flatten_eqs(eqs_initial),
             initial,
             sprintf("return %s;", dat$meta$state))
-  cpp_function(sprintf("std::vector<%s>", dat$meta$dust$float_t),
-               "initial", args, body)
+  cpp_function("std::vector<real_t>", "initial", args, body)
 }
 
 
@@ -150,9 +147,9 @@ generate_dust_core_update <- function(eqs, dat, rewrite) {
   body <- dust_flatten_eqs(c(unpack, eqs[equations]))
 
   args <- c("size_t" = dat$meta$time,
-            "const std::vector<float_t>&" = dat$meta$state,
-            "dust::RNG<float_t, int_t>&" = dat$meta$dust$rng,
-            "std::vector<float_t>&" = dat$meta$result)
+            "const std::vector<real_t>&" = dat$meta$state,
+            "dust::RNG<real_t, int_t>&" = dat$meta$dust$rng,
+            "std::vector<real_t>&" = dat$meta$result)
 
   cpp_function("void", "update", args, body)
 }
@@ -162,7 +159,7 @@ generate_dust_core_create <- function(eqs, dat, rewrite) {
   type <- sprintf("%s::init_t", dat$config$base)
 
   body <- collector()
-  body$add("typedef typename %s::float_t float_t;", dat$config$base)
+  body$add("typedef typename %s::real_t real_t;", dat$config$base)
   body$add("typedef typename %s::int_t int_t;", dat$config$base)
   body$add("%s %s;", type, dat$meta$internal)
   body$add(dust_flatten_eqs(eqs[dat$components$create$equations]))

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -160,7 +160,15 @@ generate_dust_core_create <- function(eqs, dat, rewrite) {
 
   body <- collector()
   body$add("typedef typename %s::real_t real_t;", dat$config$base)
-  body$add("typedef typename %s::int_t int_t;", dat$config$base)
+
+  ## Only add the integer typedef if we might need it, in order to
+  ## avoid a compiler warning about an unused typedef.  This is
+  ## slightly too generous (it might create the typedef when not
+  ## needed) but that's better than the reverse.
+  has_int <- any(vcapply(dat$data$elements, "[[", "storage_type") == "int")
+  if (has_int) {
+    body$add("typedef typename %s::int_t int_t;", dat$config$base)
+  }
   body$add("%s %s;", type, dat$meta$internal)
   body$add(dust_flatten_eqs(eqs[dat$components$create$equations]))
 

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -22,7 +22,7 @@ generate_dust_equation <- function(eq, dat, rewrite) {
 generate_dust_equation_scalar <- function(eq, data_info, dat, rewrite) {
   location <- data_info$location
   if (location == "transient") {
-    lhs <- sprintf("%s %s", data_info$storage_type, eq$lhs)
+    lhs <- sprintf("%s %s", dust_type(data_info$storage_type), eq$lhs)
   } else if (location == "internal") {
     lhs <- rewrite(eq$lhs)
   } else {
@@ -44,7 +44,7 @@ generate_dust_equation_array <- function(eq, data_info, dat, rewrite) {
 
 generate_dust_equation_alloc <- function(eq, data_info, dat, rewrite) {
   lhs <- rewrite(eq$lhs)
-  ctype <- data_info$storage_type
+  ctype <- dust_type(data_info$storage_type)
   len <- rewrite(data_info$dimnames$length)
   sprintf("%s = std::vector<%s>(%s);", lhs, ctype, len)
 }
@@ -55,8 +55,8 @@ generate_dust_equation_user <- function(eq, data_info, dat, rewrite) {
   rank <- data_info$rank
 
   lhs <- rewrite(eq$lhs)
-  storage_type <- data_info$storage_type
-  is_integer <- if (storage_type == "int") "true" else "false"
+  storage_type <- dust_type(data_info$storage_type)
+  is_integer <- if (storage_type == "int_t") "true" else "false"
   min <- rewrite(eq$user$min %||% "NA_REAL")
   max <- rewrite(eq$user$max %||% "NA_REAL")
   previous <- lhs
@@ -64,7 +64,7 @@ generate_dust_equation_user <- function(eq, data_info, dat, rewrite) {
   if (eq$user$dim) {
     len <- data_info$dimnames$length
     ret <- c(
-      sprintf("std::array <int, %d> %s;", rank, len),
+      sprintf("std::array <int_t, %d> %s;", rank, len),
       sprintf(
         '%s = user_get_array_variable<%s, %s>(user, "%s", %s, %s, %s, %s);',
         lhs, storage_type, rank, eq$lhs, previous, len, min, max),
@@ -79,7 +79,7 @@ generate_dust_equation_user <- function(eq, data_info, dat, rewrite) {
     if (rank == 0L) {
       ret <- sprintf(
         '%s = user_get_scalar<%s>(%s, "%s", %s, %s, %s);',
-        lhs, data_info$storage_type, user, eq$lhs, lhs, min, max)
+        lhs, storage_type, user, eq$lhs, lhs, min, max)
     } else {
       if (rank == 1L) {
         dim <- rewrite(data_info$dimnames$length)
@@ -127,13 +127,13 @@ generate_dust_equation_array_rhs <- function(value, index, lhs, rewrite) {
   for (idx in rev(index)) {
     if (idx$is_range) {
       seen_range <- TRUE
-      loop <- sprintf("for (int %s = %s; %s <= %s; ++%s) {",
+      loop <- sprintf("for (int_t %s = %s; %s <= %s; ++%s) {",
                       idx$index, rewrite(idx$value[[2]]),
                       idx$index, rewrite(idx$value[[3]]),
                       idx$index)
       ret <- c(loop, paste0("  ", ret), "}")
     } else {
-      ret <- c(sprintf("int %s = %s;", idx$index, rewrite(idx$value)),
+      ret <- c(sprintf("int_t %s = %s;", idx$index, rewrite(idx$value)),
                ret)
     }
   }

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -15,7 +15,7 @@ generate_dust_sexp <- function(x, data, meta) {
       ret <- sprintf("std::pow(%s, %s)", values[[1]], values[[2]])
     } else if (n == 2L && fn %in% odin:::FUNCTIONS_INFIX) {
       fmt <- switch(fn,
-                    "/" = "%s %s (double) %s",
+                    "/" = "%s %s (float_t) %s",
                     "%s %s %s")
       ret <- sprintf(fmt, values[[1]], fn, values[[2]])
     } else if (n == 1L && fn == "-") {

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -15,7 +15,7 @@ generate_dust_sexp <- function(x, data, meta) {
       ret <- sprintf("std::pow(%s, %s)", values[[1]], values[[2]])
     } else if (n == 2L && fn %in% odin:::FUNCTIONS_INFIX) {
       fmt <- switch(fn,
-                    "/" = "%s %s (float_t) %s",
+                    "/" = "%s %s (real_t) %s",
                     "%s %s %s")
       ret <- sprintf(fmt, values[[1]], fn, values[[2]])
     } else if (n == 1L && fn == "-") {

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -61,8 +61,6 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
   path <- tempfile(fileext = ".cpp")
   writeLines(code, path)
 
-  writeLines(code, "code.cpp")
-
   dust::dust(path, quiet = !options$verbose)
 }
 

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -15,30 +15,36 @@
 ##'   be verbose.  Defaults to the value of the option
 ##'   \code{odin.verbose} or \code{FALSE} otherwise.
 ##'
+##' @param real_t C++ type to use for real (floating point)
+##'   numbers. Defaults to \code{double}.
+##'
+##' @param int_t C++ type to use to use for integers. Defaults to
+##'   \code{int}.
+##'
 ##' @export
 ##' @importFrom odin odin
-odin_dust <- function(x, verbose = NULL) {
+odin_dust <- function(x, verbose = NULL, real_t = NULL, int_t = NULL) {
   xx <- substitute(x)
   if (is.symbol(xx)) {
     xx <- force(x)
   } else if (is_call(xx, quote(c)) && all(vlapply(xx[-1], is.character))) {
     xx <- force(x)
   }
-  odin_dust_(xx, verbose)
+  odin_dust_(xx, verbose, real_t, int_t)
 }
 
 
 ##' @export
 ##' @rdname odin_dust
-odin_dust_ <- function(x, verbose = NULL) {
+odin_dust_ <- function(x, verbose = NULL, real_t = NULL, int_t = NULL) {
   options <- odin::odin_options(target = "dust", verbose = verbose)
   ir <- odin::odin_parse_(x, options)
-  odin_dust_wrapper(ir, options)
+  odin_dust_wrapper(ir, options, real_t, int_t)
 }
 
 
-odin_dust_wrapper <- function(ir, options) {
-  res <- generate_dust(ir, options)
+odin_dust_wrapper <- function(ir, options, real_t, int_t) {
+  res <- generate_dust(ir, options, real_t, int_t)
 
   code <- c(
     dust_flatten_eqs(lapply(res$support, "[[", "declaration")),
@@ -55,5 +61,18 @@ odin_dust_wrapper <- function(ir, options) {
   path <- tempfile(fileext = ".cpp")
   writeLines(code, path)
 
+  writeLines(code, "code.cpp")
+
   dust::dust(path, quiet = !options$verbose)
+}
+
+
+odin_dust_generate_standalone <- function(ir, options) {
+  res <- generate_dust(ir, options)
+
+  c(dust_flatten_eqs(lapply(res$support, "[[", "declaration")),
+    res$class,
+    dust_flatten_eqs(lapply(res$support, "[[", "definition")),
+    readLines(odin_dust_file("support.hpp")),
+    res$create)
 }

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -63,14 +63,3 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
 
   dust::dust(path, quiet = !options$verbose)
 }
-
-
-odin_dust_generate_standalone <- function(ir, options) {
-  res <- generate_dust(ir, options)
-
-  c(dust_flatten_eqs(lapply(res$support, "[[", "declaration")),
-    res$class,
-    dust_flatten_eqs(lapply(res$support, "[[", "definition")),
-    readLines(odin_dust_file("support.hpp")),
-    res$create)
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,7 @@ generate_dust_support_sum <- function(rank) {
 
 dust_type <- function(type) {
   switch(type,
-         double = "float_t",
+         double = "real_t",
          int = "int_t",
          stop(sprintf("Unknown type '%s'", type)))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,11 @@ generate_dust_support_sum <- function(rank) {
       sub("double*", "const std::vector<double>&", x, fixed = TRUE))
   }
 }
+
+
+dust_type <- function(type) {
+  switch(type,
+         double = "float_t",
+         int = "int_t",
+         stop(sprintf("Unknown type '%s'", type)))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,8 +89,17 @@ generate_dust_support_sum <- function(rank) {
            "T odin_sum1(const std::vector<T>& x, size_t from, size_t to);"),
          definition = NULL)
   } else {
-    lapply(odin:::generate_c_support_sum(rank), function(x)
-      sub("double*", "const std::vector<double>&", x, fixed = TRUE))
+    ## There are a series of substitutions that need to be made here,
+    ## all of which are literal
+    tr <- c("double*" = "const std::vector<real_t>&",
+            "double" = "real_t",
+            "int" = "int_t")
+    ## Then set up as templates over real_t, int_t
+    head <- "template <typename real_t, typename int_t>"
+    ret <- lapply(odin:::generate_c_support_sum(rank), replace, tr)
+    ret$declaration <- c(head, ret$declaration)
+    ret$definition <- c(head, ret$definition)
+    ret
   }
 }
 
@@ -100,4 +109,13 @@ dust_type <- function(type) {
          double = "real_t",
          int = "int_t",
          stop(sprintf("Unknown type '%s'", type)))
+}
+
+
+replace <- function(x, tr) {
+  from <- names(tr)
+  for (i in seq_along(tr)) {
+    x <- gsub(from[[i]], tr[[i]], x, fixed = TRUE)
+  }
+  x
 }

--- a/inst/support.hpp
+++ b/inst/support.hpp
@@ -56,7 +56,6 @@ void user_check_array_value(const std::vector<T>& value, const char *name,
   }
 }
 
-
 size_t user_get_array_rank(Rcpp::RObject x) {
   if (x.hasAttribute("dim")) {
     Rcpp::IntegerVector dim = x.attr("dim");
@@ -140,6 +139,19 @@ T user_get_scalar(Rcpp::List user, const char *name,
   return ret;
 }
 
+// This is not actually really enough to work generally as there's an
+// issue with what to do with checking previous, min and max against
+// NA_REAL -- which is not going to be the correct value for float
+// rather than double.  Further, this is not extendable to the vector
+// cases because we hit issues around partial template specification.
+//
+// We can make the latter go away by replacing std::array<T, N> with
+// std::vector<T> - the cost is not great.  But the NA issues remain
+// and will require further thought. However, this template
+// specialisation and the tests that use it ensure that the core code
+// generation is at least compatible with floats.
+//
+// See #6
 template <>
 float user_get_scalar<float>(Rcpp::List user, const char *name,
                              const float previous, float min, float max) {

--- a/inst/support.hpp
+++ b/inst/support.hpp
@@ -140,6 +140,13 @@ T user_get_scalar(Rcpp::List user, const char *name,
   return ret;
 }
 
+template <>
+float user_get_scalar<float>(Rcpp::List user, const char *name,
+                             const float previous, float min, float max) {
+  double value = user_get_scalar<double>(user, name, previous, min, max);
+  return static_cast<float>(value);
+}
+
 template <typename T, size_t N>
 std::vector<T> user_get_array_fixed(Rcpp::List user, const char *name,
                                     const std::vector<T> previous,

--- a/man/odin_dust.Rd
+++ b/man/odin_dust.Rd
@@ -5,9 +5,9 @@
 \alias{odin_dust_}
 \title{Create a dust odin model}
 \usage{
-odin_dust(x, verbose = NULL)
+odin_dust(x, verbose = NULL, real_t = NULL, int_t = NULL)
 
-odin_dust_(x, verbose = NULL)
+odin_dust_(x, verbose = NULL, real_t = NULL, int_t = NULL)
 }
 \arguments{
 \item{x}{Either the name of a file to read, a text string (if
@@ -17,6 +17,12 @@ or an expression.}
 \item{verbose}{Logical scalar indicating if the compilation should
 be verbose.  Defaults to the value of the option
 \code{odin.verbose} or \code{FALSE} otherwise.}
+
+\item{real_t}{C++ type to use for real (floating point)
+numbers. Defaults to \code{double}.}
+
+\item{int_t}{C++ type to use to use for integers. Defaults to
+\code{int}.}
 }
 \description{
 Compile an odin model to work with dust.

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -217,3 +217,23 @@ test_that("NSE interface can accept a character vector", {
     mockery::mock_args(mock_target)[[1]],
     list(c("a", "b", "c"), NULL))
 })
+
+
+test_that("don't encode specific types in generated code", {
+  options <- odin::odin_options(target = "dust")
+  ir <- odin::odin_parse_("examples/sir.R", options)
+  res <- generate_dust(ir, options)
+
+  expect_equal(sum(grepl("double", res$class)), 1)
+  expect_match(grep("double", res$class, value = TRUE),
+               "typedef double real_t;")
+  expect_equal(sum(grepl("double", res$create)), 0)
+
+  ## A bit harder; this regex reads as "the string 'int' on a word
+  ## boundary followed by a character that is not an underscore"
+  re_int <- "int\\b[^_]"
+  expect_equal(sum(grepl(re_int, res$class)), 1)
+  expect_match(grep(re_int, res$class, value = TRUE),
+               "typedef int int_t;")
+  expect_equal(sum(grepl(re_int, res$create)), 0)
+})

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -202,7 +202,7 @@ test_that("NSE interface can accept a symbol and resolve to value", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(path, NULL))
+    list(path, NULL, NULL, NULL))
 })
 
 
@@ -215,7 +215,7 @@ test_that("NSE interface can accept a character vector", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(c("a", "b", "c"), NULL))
+    list(c("a", "b", "c"), NULL, NULL, NULL))
 })
 
 

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -251,3 +251,27 @@ test_that("Generate code with different types", {
   expect_equal(replace(res$class, c(DOUBLE = "double", INT = "int")),
                cmp$class)
 })
+
+
+test_that("sir model float test", {
+  gen_f <- odin_dust_("examples/sir.R", real_t = "float")
+  gen_d <- odin_dust_("examples/sir.R", real_t = "double")
+
+  n <- 10000
+  y0 <- c(1000, 10, 0)
+  p <- list(I_ini = 10)
+
+  mod_f <- gen_f$new(p, 0L, n)
+  mod_f$run(200)
+  y_f <- mod_f$state()
+
+  mod_d <- gen_d$new(p, 0L, n)
+  mod_d$run(200)
+  y_d <- mod_d$state()
+
+  ## Not the same
+  expect_false(isTRUE(all.equal(y_f, y_d)))
+
+  ## But the same distribution
+  expect_equal(rowMeans(y_f), rowMeans(y_d), tolerance = 0.01)
+})

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -237,3 +237,17 @@ test_that("don't encode specific types in generated code", {
                "typedef int int_t;")
   expect_equal(sum(grepl(re_int, res$create)), 0)
 })
+
+
+test_that("Generate code with different types", {
+  options <- odin::odin_options(target = "dust")
+  ir <- odin::odin_parse_("examples/sir.R", options)
+  res <- generate_dust(ir, options, "DOUBLE", "INT")
+
+  expect_true(any(grepl("typedef INT int_t;", res$class)))
+  expect_true(any(grepl("typedef DOUBLE real_t;", res$class)))
+
+  cmp <- generate_dust(ir, options)
+  expect_equal(replace(res$class, c(DOUBLE = "double", INT = "int")),
+               cmp$class)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -6,3 +6,10 @@ test_that("null-or-value works", {
   expect_equal(NULL %||% NULL, NULL)
   expect_equal(NULL %||% 2, 2)
 })
+
+
+test_that("dust_type errors on unknown types", {
+  expect_equal(dust_type("int"), "int_t")
+  expect_equal(dust_type("double"), "real_t")
+  expect_error(dust_type("void"), "Unknown type 'void'")
+})


### PR DESCRIPTION
This PR starts the process of making odin.dust capable of generating models with different real and integer types. The type is pulled through from the interface and added to the generated code - that part is pretty straightforward.

There's some harder work to be done in the user handling, and as such user-vectors are not supported in float-using models (see #6 for details)

**NOTE**: Update branch pin in .travis.yml before merge, after the dust PR is merged

Requires https://github.com/mrc-ide/dust/pull/28
Fixes #4 