### PR TITLE
i7 - return variable order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust
+  - mrc-ide/dust@i24-info
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust@i24-info
+  - mrc-ide/dust
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),
@@ -17,7 +17,7 @@ Language: en-GB
 URL: https://github.com/mrc-ide/odin.dust
 BugReports: https://github.com/mrc-ide/odin.dust/issues
 Imports:
-    dust (>= 0.0.2),
+    dust (>= 0.0.3),
     odin
 Suggests:
     Rcpp,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Language: en-GB
 URL: https://github.com/mrc-ide/odin.dust
 BugReports: https://github.com/mrc-ide/odin.dust/issues
 Imports:
+    R6,
     dust (>= 0.0.3),
     odin
 Suggests:

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -64,6 +64,7 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
 
   generator <- dust::dust(path, quiet = !options$verbose)
 
+  self <- NULL # this will be resolved by R6
   R6::R6Class(
     inherit = generator,
     public = list(

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -64,13 +64,17 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
 
   generator <- dust::dust(path, quiet = !options$verbose)
 
-  self <- NULL # avoid a NOTE; the real self will come from the class
-  generator$set("public", "index", function() dust_index(self$info()))
-  generator
+  R6::R6Class(
+    inherit = generator,
+    public = list(
+      index = function() {
+        odin_dust_index(self$info())
+      }
+    ))
 }
 
 
-dust_index <- function(info) {
+odin_dust_index <- function(info) {
   n <- vnapply(info, prod)
   Map(seq.int, to = cumsum(n), by = 1L, length.out = n)
 }

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -51,7 +51,8 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
     res$class,
     dust_flatten_eqs(lapply(res$support, "[[", "definition")),
     readLines(odin_dust_file("support.hpp")),
-    res$create)
+    res$create,
+    res$info)
 
   workdir <- options$workdir
   if (workdir == tempdir()) {

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -62,5 +62,15 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
   path <- tempfile(fileext = ".cpp")
   writeLines(code, path)
 
-  dust::dust(path, quiet = !options$verbose)
+  generator <- dust::dust(path, quiet = !options$verbose)
+
+  self <- NULL # avoid a NOTE; the real self will come from the class
+  generator$set("public", "index", function() dust_index(self$info()))
+  generator
+}
+
+
+dust_index <- function(info) {
+  n <- vnapply(info, prod)
+  Map(seq.int, to = cumsum(n), by = 1L, length.out = n)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,6 +31,11 @@ dust_fold_call <- function(...) {
 }
 
 
+dquote <- function(...) {
+  odin:::dquote(...)
+}
+
+
 squote <- function(...) {
   odin:::squote(...)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,6 +11,10 @@ viapply <- function(x, fun, ...) {
   vapply(x, fun, integer(1), ...)
 }
 
+vnapply <- function(x, fun, ...) {
+  vapply(x, fun, numeric(1), ...)
+}
+
 vcapply <- function(x, fun, ...) {
   vapply(x, fun, character(1), ...)
 }

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -11,6 +11,7 @@ test_that("sir model smoke test", {
   expect_equal(mod$state(), matrix(y0, 3, n))
   expect_equal(mod$step(), 0)
   expect_identical(mod$info(), list(S = 1L, I = 1L, R = 1L))
+  expect_equal(mod$index(), list(S = 1L, I = 2L, R = 3L))
 
   nstep <- 200
   res <- array(NA_real_, c(3, n, nstep + 1))
@@ -158,6 +159,10 @@ test_that("Implement sum", {
     mod$info(),
     list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L))
   expect_equal(names(yy)[-1], names(mod$info()))
+
+  expect_equal(
+    mod$index(),
+    cmp(m)$transform_variables(seq_len(26))[-1])
 
   expect_equal(yy$tot1, sum(m))
   expect_equal(yy$tot2, sum(m))

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -10,6 +10,7 @@ test_that("sir model smoke test", {
   mod <- gen$new(list(I_ini = 10), 0L, n)
   expect_equal(mod$state(), matrix(y0, 3, n))
   expect_equal(mod$step(), 0)
+  expect_identical(mod$info(), list(S = 1L, I = 1L, R = 1L))
 
   nstep <- 200
   res <- array(NA_real_, c(3, n, nstep + 1))
@@ -37,6 +38,7 @@ test_that("vector handling test", {
   mod <- gen$new(list(), 0L, np)
   expect_equal(mod$state(), matrix(0, ns, np))
   expect_equal(mod$step(), 0)
+  expect_identical(mod$info(), list(x = 3L))
 
   y1 <- mod$run(nt)
   y2 <- mod$state()
@@ -57,6 +59,7 @@ test_that("user-vector handling test", {
   x0 <- matrix(runif(10), 2, 5)
 
   mod <- gen$new(list(x0 = x0, r = r), 0, 1)
+  expect_identical(mod$info(), list(x = c(2L, 5L)))
 
   expect_equal(mod$state(), matrix(c(x0)))
   expect_equal(mod$step(), 0)
@@ -95,6 +98,7 @@ test_that("multiline array expression", {
     dim(x) <- length(x0)
   }, verbose = FALSE)
   mod <- gen$new(list(), 0, 1)
+  expect_equal(mod$info(), list(y = 1L, x = 10L))
   expect_equal(mod$state(), matrix(c(55, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55)))
 })
 
@@ -143,11 +147,18 @@ test_that("Implement sum", {
   nc <- 7
   m <- matrix(runif(nr * nc), nr, nc)
   mod <- gen$new(list(m = m), 0, 1)
+
   mod$run(1)
   y <- mod$state()
   ## TODO: See #2
   cmp <- odin::odin_("examples/sum.R", target = "r", verbose = FALSE)
   yy <- cmp(m)$transform_variables(drop(y))
+
+  expect_mapequal(
+    mod$info(),
+    list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L))
+  expect_equal(names(yy)[-1], names(mod$info()))
+
   expect_equal(yy$tot1, sum(m))
   expect_equal(yy$tot2, sum(m))
   expect_equal(yy$v1, rowSums(m))


### PR DESCRIPTION
This PR uses the support in https://github.com/mrc-ide/dust/pull/30 to return variable ordering information back from dust. This is needed because odin is allowed to reorder variables as it wants (i.e. the way that the state vector is packed - roughly it will be scalars then vectors, I think each in topological order given the graph).

We provide two methods here:

* `$info()` comes directly from the support in dust and here returns something like: `list(x = 1, y = 10, z = c(3, 5))` which would mean `x` is a scalar `y` is a vector of length 10 and `z` is a matrix if 3 rows and 5 columns
* `$index()` returns the *index* to the state vector (given that) so `list(x = 1, y = 2:11, z = 12:56)`

With this, in sircovid we can then get the deaths index out for the compare function, but we still need a way of setting this in the object (https://github.com/mrc-ide/dust/issues/8). It will also be useful for filtering the state generally rather than the big `state()` call that we have (https://github.com/mrc-ide/dust/issues/21)

Fixes #7
Fixes #2 