### PR TITLE
i15: fix sum for variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.0.4
+Version: 0.0.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -80,6 +80,11 @@ generate_dust_sexp <- function(x, data, meta) {
 generate_dust_sexp_sum <- function(args, data, meta) {
   target <- generate_dust_sexp(args[[1]], data, meta)
   data_info <- data$elements[[args[[1]]]]
+
+  if (data_info$location == "internal") {
+    target <- sprintf("%s.data()", target)
+  }
+
   if (length(args) == 1L) {
     len <- generate_dust_sexp(data_info$dimnames$length, data, meta)
     sprintf("odin_sum1(%s, 0, %s)", target, len)
@@ -91,6 +96,7 @@ generate_dust_sexp_sum <- function(args, data, meta) {
     values[i] <- vcapply(all_args[i], dust_minus_1, FALSE, data, meta)
     values[-i] <- vcapply(all_args[-i], generate_dust_sexp,
                           data, meta)
+    values[[1]] <- target
     arg_str <- paste(values, collapse = ", ")
 
     sprintf("odin_sum%d(%s)", length(i), arg_str)

--- a/R/utils.R
+++ b/R/utils.R
@@ -91,12 +91,12 @@ generate_dust_support_sum <- function(rank) {
     list(name = "odin_sum1",
          declaration = c(
            "template <typename T>",
-           "T odin_sum1(const std::vector<T>& x, size_t from, size_t to);"),
+           "T odin_sum1(const T * x, size_t from, size_t to);"),
          definition = NULL)
   } else {
     ## There are a series of substitutions that need to be made here,
     ## all of which are literal
-    tr <- c("double*" = "const std::vector<real_t>&",
+    tr <- c("double*" = "const real_t *",
             "double" = "real_t",
             "int" = "int_t")
     ## Then set up as templates over real_t, int_t

--- a/inst/support.hpp
+++ b/inst/support.hpp
@@ -209,7 +209,7 @@ std::vector<T> user_get_array_variable(cpp11::list user, const char *name,
 // This is sum with inclusive "from", exclusive "to", following the
 // same function in odin
 template <typename T>
-T odin_sum1(const std::vector<T>& x, size_t from, size_t to) {
+T odin_sum1(const T * x, size_t from, size_t to) {
   T tot = 0.0;
   for (size_t i = from; i < to; ++i) {
     tot += x[i];

--- a/tests/testthat/examples/sum2.R
+++ b/tests/testthat/examples/sum2.R
@@ -1,0 +1,63 @@
+## Force the core arrays to be in the initial conditions in order to
+## make them slices of the state, rather than proper vectors.
+y0[, , ] <- user()
+dim(y0) <- user()
+update(y[, , ]) <- y[i, j, k] # trivial model!
+initial(y[, , ]) <- y0[i, j, k]
+dim(y) <- c(dim(y0, 1), dim(y0, 2), dim(y0, 3))
+
+## These collapse one dimension
+update(m12[, ]) <- sum(y[i, j, ])
+update(m13[, ]) <- sum(y[i, , j])
+update(m23[, ]) <- sum(y[, i, j])
+
+initial(m12[, ]) <- sum(y0[i, j, ])
+initial(m13[, ]) <- sum(y0[i, , j])
+initial(m23[, ]) <- sum(y0[, i, j])
+
+dim(m12) <- c(dim(y, 1), dim(y, 2))
+dim(m13) <- c(dim(y, 1), dim(y, 3))
+dim(m23) <- c(dim(y, 2), dim(y, 3))
+
+## These collapse two dimensions
+update(v1[]) <- sum(y[i, , ])
+update(v2[]) <- sum(y[, i, ])
+update(v3[]) <- sum(y[, , i])
+
+initial(v1[]) <- sum(y0[i, , ])
+initial(v2[]) <- sum(y0[, i, ])
+initial(v3[]) <- sum(y0[, , i])
+
+dim(v1) <- dim(y, 1)
+dim(v2) <- dim(y, 2)
+dim(v3) <- dim(y, 3)
+
+update(mm12[, ]) <- sum(y[i, j, 2:4])
+update(mm13[, ]) <- sum(y[i, 2:4, j])
+update(mm23[, ]) <- sum(y[2:4, i, j])
+
+initial(mm12[, ]) <- sum(y0[i, j, 2:4])
+initial(mm13[, ]) <- sum(y0[i, 2:4, j])
+initial(mm23[, ]) <- sum(y0[2:4, i, j])
+
+dim(mm12) <- c(dim(y, 1), dim(y, 2))
+dim(mm13) <- c(dim(y, 1), dim(y, 3))
+dim(mm23) <- c(dim(y, 2), dim(y, 3))
+
+update(vv1[]) <- sum(y[i, 2:4, 2:4])
+update(vv2[]) <- sum(y[2:4, i, 2:4])
+update(vv3[]) <- sum(y[2:4, 2:4, i])
+
+initial(vv1[]) <- sum(y0[i, 2:4, 2:4])
+initial(vv2[]) <- sum(y0[2:4, i, 2:4])
+initial(vv3[]) <- sum(y0[2:4, 2:4, i])
+
+dim(vv1) <- dim(y, 1)
+dim(vv2) <- dim(y, 2)
+dim(vv3) <- dim(y, 3)
+
+update(tot1) <- sum(y)
+update(tot2) <- sum(y[, , ])
+
+initial(tot1) <- sum(y0)
+initial(tot2) <- sum(y0[, , ])

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -197,13 +197,13 @@ test_that("sum over variables", {
   expect_equal(y0$v2, apply(a, 2, sum))
   expect_equal(y0$v3, apply(a, 3, sum))
 
-  expect_equal(y0$mm12, apply(a[,,2:4], 1:2, sum))
-  expect_equal(y0$mm13, apply(a[,2:4,], c(1, 3), sum))
-  expect_equal(y0$mm23, apply(a[2:4,,], 2:3, sum))
+  expect_equal(y0$mm12, apply(a[, , 2:4], 1:2, sum))
+  expect_equal(y0$mm13, apply(a[, 2:4, ], c(1, 3), sum))
+  expect_equal(y0$mm23, apply(a[2:4, , ], 2:3, sum))
 
-  expect_equal(y0$vv1, apply(a[,2:4,2:4], 1, sum))
-  expect_equal(y0$vv2, apply(a[2:4,,2:4], 2, sum))
-  expect_equal(y0$vv3, apply(a[2:4,2:4,], 3, sum))
+  expect_equal(y0$vv1, apply(a[, 2:4, 2:4], 1, sum))
+  expect_equal(y0$vv2, apply(a[2:4, , 2:4], 2, sum))
+  expect_equal(y0$vv3, apply(a[2:4, 2:4, ], 3, sum))
 
   expect_equal(y0$tot1, sum(a))
   expect_equal(y0$tot2, sum(a))
@@ -218,13 +218,13 @@ test_that("sum over variables", {
   expect_equal(y1$v2, apply(a, 2, sum))
   expect_equal(y1$v3, apply(a, 3, sum))
 
-  expect_equal(y1$mm12, apply(a[,,2:4], 1:2, sum))
-  expect_equal(y1$mm13, apply(a[,2:4,], c(1, 3), sum))
-  expect_equal(y1$mm23, apply(a[2:4,,], 2:3, sum))
+  expect_equal(y1$mm12, apply(a[, , 2:4], 1:2, sum))
+  expect_equal(y1$mm13, apply(a[, 2:4, ], c(1, 3), sum))
+  expect_equal(y1$mm23, apply(a[2:4, , ], 2:3, sum))
 
-  expect_equal(y1$vv1, apply(a[,2:4,2:4], 1, sum))
-  expect_equal(y1$vv2, apply(a[2:4,,2:4], 2, sum))
-  expect_equal(y1$vv3, apply(a[2:4,2:4,], 3, sum))
+  expect_equal(y1$vv1, apply(a[, 2:4, 2:4], 1, sum))
+  expect_equal(y1$vv2, apply(a[2:4, , 2:4], 2, sum))
+  expect_equal(y1$vv3, apply(a[2:4, 2:4, ], 3, sum))
 
   expect_equal(y1$tot1, sum(a))
   expect_equal(y1$tot2, sum(a))

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -174,6 +174,63 @@ test_that("Implement sum", {
 })
 
 
+test_that("sum over variables", {
+  gen <- odin_dust_("examples/sum2.R", verbose = FALSE)
+
+  nr <- 5
+  nc <- 7
+  nz <- 9
+  a <- array(runif(nr * nc * nz), c(nr, nc, nz))
+  mod <- gen$new(list(y0 = a), 0, 1)
+  cmp <- odin::odin_("examples/sum2.R", verbose = FALSE)(y0 = a)
+
+  y0 <- cmp$transform_variables(drop(mod$state()))
+  y1 <- cmp$transform_variables(drop(mod$run(1)))
+
+  expect_equal(y0$y, a)
+
+  expect_equal(y0$m12, apply(a, 1:2, sum))
+  expect_equal(y0$m13, apply(a, c(1, 3), sum))
+  expect_equal(y0$m23, apply(a, 2:3, sum))
+
+  expect_equal(y0$v1, apply(a, 1, sum))
+  expect_equal(y0$v2, apply(a, 2, sum))
+  expect_equal(y0$v3, apply(a, 3, sum))
+
+  expect_equal(y0$mm12, apply(a[,,2:4], 1:2, sum))
+  expect_equal(y0$mm13, apply(a[,2:4,], c(1, 3), sum))
+  expect_equal(y0$mm23, apply(a[2:4,,], 2:3, sum))
+
+  expect_equal(y0$vv1, apply(a[,2:4,2:4], 1, sum))
+  expect_equal(y0$vv2, apply(a[2:4,,2:4], 2, sum))
+  expect_equal(y0$vv3, apply(a[2:4,2:4,], 3, sum))
+
+  expect_equal(y0$tot1, sum(a))
+  expect_equal(y0$tot2, sum(a))
+
+  expect_equal(y1$y, a)
+
+  expect_equal(y1$m12, apply(a, 1:2, sum))
+  expect_equal(y1$m13, apply(a, c(1, 3), sum))
+  expect_equal(y1$m23, apply(a, 2:3, sum))
+
+  expect_equal(y1$v1, apply(a, 1, sum))
+  expect_equal(y1$v2, apply(a, 2, sum))
+  expect_equal(y1$v3, apply(a, 3, sum))
+
+  expect_equal(y1$mm12, apply(a[,,2:4], 1:2, sum))
+  expect_equal(y1$mm13, apply(a[,2:4,], c(1, 3), sum))
+  expect_equal(y1$mm23, apply(a[2:4,,], 2:3, sum))
+
+  expect_equal(y1$vv1, apply(a[,2:4,2:4], 1, sum))
+  expect_equal(y1$vv2, apply(a[2:4,,2:4], 2, sum))
+  expect_equal(y1$vv3, apply(a[2:4,2:4,], 3, sum))
+
+  expect_equal(y1$tot1, sum(a))
+  expect_equal(y1$tot2, sum(a))
+})
+
+
 test_that("odin.dust required discrete model", {
   expect_error(
     odin_dust({

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -132,10 +132,6 @@ test_that("Generate sum code", {
   expect_equal(
     generate_dust_sexp(list("sum", "m"), data, internal),
     "odin_sum1(m, 0, internal.dim_m)")
-
-  expr <- list("sum", "m",
-               1L, list("dim", "m", 1),
-               2L, list("dim", "m", 2))
   expect_equal(
     generate_dust_sexp(expr, data, internal),
     paste("odin_sum2(m, 0, internal.dim_m_1,",

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -118,14 +118,27 @@ test_that("Generate sum code", {
                                dim_m_2 = scalar_int("dim_m_2")))
   expect_equal(
     generate_dust_sexp(list("sum", "m"), data, internal),
-    "odin_sum1(internal.m, 0, internal.dim_m)")
+    "odin_sum1(internal.m.data(), 0, internal.dim_m)")
 
   expr <- list("sum", "m",
                1L, list("dim", "m", 1),
                2L, list("dim", "m", 2))
   expect_equal(
     generate_dust_sexp(expr, data, internal),
-    paste("odin_sum2(internal.m, 0, internal.dim_m_1,",
+    paste("odin_sum2(internal.m.data(), 0, internal.dim_m_1,",
+          "1, internal.dim_m_2, internal.dim_m_1)"))
+
+  data$elements$m$location <- "variable"
+  expect_equal(
+    generate_dust_sexp(list("sum", "m"), data, internal),
+    "odin_sum1(m, 0, internal.dim_m)")
+
+  expr <- list("sum", "m",
+               1L, list("dim", "m", 1),
+               2L, list("dim", "m", 2))
+  expect_equal(
+    generate_dust_sexp(expr, data, internal),
+    paste("odin_sum2(m, 0, internal.dim_m_1,",
           "1, internal.dim_m_2, internal.dim_m_1)"))
 })
 


### PR DESCRIPTION
The sum implementation was broken because we passed a different type for things stored as variables (which come out as `real_t *`) and things stored as intermediates (which come out as `std::vector<real_t>`), creating a compiler error.

This PR changes `sum` so that we use the lowest common denominator of the pointer, even though that's a bit ugly. Using iterators would be more general but somewhat harder and may not work nicely on the GPU.

Fixes #15 