### PR TITLE
i16: Pass workdir through to dust

### DIFF
--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -21,23 +21,31 @@
 ##' @param int_t C++ type to use to use for integers. Defaults to
 ##'   \code{int}.
 ##'
+##' @param workdir Working directory to use for the compilation. By
+##'   default we use a new path within the temporary directory. Passed
+##'   to \code{\link{dust}}; a mini package will be created at this
+##'   path.
+##'
 ##' @export
 ##' @importFrom odin odin
-odin_dust <- function(x, verbose = NULL, real_t = NULL, int_t = NULL) {
+odin_dust <- function(x, verbose = NULL, real_t = NULL, int_t = NULL,
+                      workdir = NULL) {
   xx <- substitute(x)
   if (is.symbol(xx)) {
     xx <- force(x)
   } else if (is_call(xx, quote(c)) && all(vlapply(xx[-1], is.character))) {
     xx <- force(x)
   }
-  odin_dust_(xx, verbose, real_t, int_t)
+  odin_dust_(xx, verbose, real_t, int_t, workdir)
 }
 
 
 ##' @export
 ##' @rdname odin_dust
-odin_dust_ <- function(x, verbose = NULL, real_t = NULL, int_t = NULL) {
-  options <- odin::odin_options(target = "dust", verbose = verbose)
+odin_dust_ <- function(x, verbose = NULL, real_t = NULL, int_t = NULL,
+                       workdir = NULL) {
+  options <- odin::odin_options(target = "dust", verbose = verbose,
+                                workdir = workdir)
   ir <- odin::odin_parse_(x, options)
   odin_dust_wrapper(ir, options, real_t, int_t)
 }
@@ -55,7 +63,7 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
   path <- tempfile(fileext = ".cpp")
   writeLines(code, path)
 
-  generator <- dust::dust(path, quiet = !options$verbose)
+  generator <- dust::dust(path, quiet = !options$verbose, workdir = workdir)
   if (!("index" %in% names(generator$public_methods))) {
     generator$set("public", "index", odin_dust_index)
   }

--- a/man/odin_dust.Rd
+++ b/man/odin_dust.Rd
@@ -5,9 +5,9 @@
 \alias{odin_dust_}
 \title{Create a dust odin model}
 \usage{
-odin_dust(x, verbose = NULL, real_t = NULL, int_t = NULL)
+odin_dust(x, verbose = NULL, real_t = NULL, int_t = NULL, workdir = NULL)
 
-odin_dust_(x, verbose = NULL, real_t = NULL, int_t = NULL)
+odin_dust_(x, verbose = NULL, real_t = NULL, int_t = NULL, workdir = NULL)
 }
 \arguments{
 \item{x}{Either the name of a file to read, a text string (if
@@ -23,6 +23,11 @@ numbers. Defaults to \code{double}.}
 
 \item{int_t}{C++ type to use to use for integers. Defaults to
 \code{int}.}
+
+\item{workdir}{Working directory to use for the compilation. By
+default we use a new path within the temporary directory. Passed
+to \code{\link{dust}}; a mini package will be created at this
+path.}
 }
 \description{
 Compile an odin model to work with dust.

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -276,7 +276,7 @@ test_that("NSE interface can accept a symbol and resolve to value", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(path, NULL, NULL, NULL))
+    list(path, NULL, NULL, NULL, NULL))
 })
 
 
@@ -289,7 +289,7 @@ test_that("NSE interface can accept a character vector", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(c("a", "b", "c"), NULL, NULL, NULL))
+    list(c("a", "b", "c"), NULL, NULL, NULL, NULL))
 })
 
 

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -349,3 +349,15 @@ test_that("sir model float test", {
   ## But the same distribution
   expect_equal(rowMeans(y_f), rowMeans(y_d), tolerance = 0.01)
 })
+
+
+test_that("specify workdir", {
+  path <- tempfile()
+  gen <- odin_dust({
+    initial(x) <- 0
+    update(x) <- runif(x, 1)
+  }, verbose = FALSE, workdir = path)
+  expect_true(file.exists(path))
+  expect_true(file.exists(file.path(path, "DESCRIPTION")))
+  expect_true(file.exists(file.path(path, "src", "dust.cpp")))
+})


### PR DESCRIPTION
This PR just passes the `workdir` argument through to dust, which allows for persistent models, and easier inspection of the code.

Fixes #16 