### PR TITLE
i20: update to dust 0.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust
+  - mrc-ide/dust@i71-pointers
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust@i71-pointers
+  - mrc-ide/dust
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust@i60-rng-state
+  - mrc-ide/dust
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ addons:
 r_packages:
   - covr
 r_github_packages:
-  - mrc-ide/dust
+  - mrc-ide/dust@i60-rng-state
 after_success:
   - Rscript -e 'covr::codecov(quiet = FALSE)'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ URL: https://github.com/mrc-ide/odin.dust
 BugReports: https://github.com/mrc-ide/odin.dust/issues
 Imports:
     R6,
-    dust (>= 0.3.0),
+    dust (>= 0.4.1),
     odin
 Suggests:
     brio,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),
@@ -18,7 +18,7 @@ URL: https://github.com/mrc-ide/odin.dust
 BugReports: https://github.com/mrc-ide/odin.dust/issues
 Imports:
     R6,
-    dust (>= 0.2.4),
+    dust (>= 0.3.0),
     odin
 Suggests:
     brio,

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -154,8 +154,6 @@ generate_dust_core_update <- function(eqs, dat, rewrite) {
             "const real_t *" = dat$meta$state,
             "dust::rng_state_t<real_t>&" = dat$meta$dust$rng_state,
             "real_t *" = dat$meta$result)
-  return_type <- "void"
-  name <- "update"
   c("#ifdef __NVCC__",
     "__device__",
     "#endif",

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -42,7 +42,7 @@ generate_dust <- function(ir, options, real_t = NULL, int_t = NULL) {
 
 
 generate_dust_meta <- function(real_t, int_t) {
-  list(rng = "rng",
+  list(rng_state = "rng_state",
        real_t = real_t %||% "double",
        int_t = int_t %||% "int")
 }
@@ -152,7 +152,7 @@ generate_dust_core_update <- function(eqs, dat, rewrite) {
 
   args <- c("size_t" = dat$meta$time,
             "const std::vector<real_t>&" = dat$meta$state,
-            "dust::RNG<real_t, int_t>&" = dat$meta$dust$rng,
+            "dust::rng_state_t<real_t>&" = dat$meta$dust$rng_state,
             "std::vector<real_t>&" = dat$meta$result)
 
   cpp_function("void", "update", args, body)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -150,25 +150,16 @@ generate_dust_core_update <- function(eqs, dat, rewrite) {
                    dat, dat$meta$state, rewrite)
   body <- dust_flatten_eqs(c(unpack, eqs[equations]))
 
-  args_cpu <- c("size_t" = dat$meta$time,
-                "const std::vector<real_t>&" = dat$meta$state,
-                "dust::rng_state_t<real_t>&" = dat$meta$dust$rng_state,
-                "std::vector<real_t>&" = dat$meta$result)
-  args_gpu <- c("size_t" = dat$meta$time,
-                "const real_t *" = dat$meta$state,
-                "dust::rng_state_t<real_t>&" = dat$meta$dust$rng_state,
-                "real_t *" = dat$meta$result)
+  args <- c("size_t" = dat$meta$time,
+            "const real_t *" = dat$meta$state,
+            "dust::rng_state_t<real_t>&" = dat$meta$dust$rng_state,
+            "real_t *" = dat$meta$result)
   return_type <- "void"
   name <- "update"
-
   c("#ifdef __NVCC__",
     "__device__",
-    cpp_args(return_type, name, args_gpu),
-    "#else",
-    cpp_args(return_type, name, args_cpu),
     "#endif",
-    paste0("  ", body),
-    "}")
+    cpp_function("void", "update", args, body))
 }
 
 
@@ -280,6 +271,6 @@ dust_extract_variable <- function(x, data_elements, state, rewrite) {
     ## Using a wrapper here would be more C++'ish but is it needed?
     offset <- rewrite(x$offset)
     len <- rewrite(d$dimnames$length)
-    sprintf("%s.data() + %s", state, offset)
+    sprintf("%s + %s", state, offset)
   }
 }

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -48,8 +48,8 @@ generate_dust_sexp <- function(x, data, meta) {
         ## useful most of the time).
         values[[1L]] <- sprintf("std::round(%s)", values[[1L]])
       }
-      ret <- sprintf("%s.%s(%s)",
-                     meta$dust$rng, fn, paste(values, collapse = ", "))
+      ret <- sprintf("dust::distr::%s(%s, %s)",
+                     fn, meta$dust$rng_state, paste(values, collapse = ", "))
     } else {
       if (any(names(FUNCTIONS_RENAME) == fn)) {
         fn <- FUNCTIONS_RENAME[[fn]]

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -53,7 +53,7 @@ odin_dust_ <- function(x, verbose = NULL, real_t = NULL, int_t = NULL,
 }
 
 
-odin_dust_wrapper <- function(ir, options, real_t, int_t) {
+odin_dust_wrapper <- function(ir, options, real_t, int_t, gpu) {
   dat <- generate_dust(ir, options, real_t, int_t)
   code <- odin_dust_code(dat, real_t, int_t)
 

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -26,28 +26,30 @@
 ##'   to \code{\link{dust}}; a mini package will be created at this
 ##'   path.
 ##'
+##' @param gpu Use the GPU
+##'
 ##' @export
 ##' @importFrom odin odin
 odin_dust <- function(x, verbose = NULL, real_t = NULL, int_t = NULL,
-                      workdir = NULL) {
+                      workdir = NULL, gpu = FALSE) {
   xx <- substitute(x)
   if (is.symbol(xx)) {
     xx <- force(x)
   } else if (is_call(xx, quote(c)) && all(vlapply(xx[-1], is.character))) {
     xx <- force(x)
   }
-  odin_dust_(xx, verbose, real_t, int_t, workdir)
+  odin_dust_(xx, verbose, real_t, int_t, workdir, gpu)
 }
 
 
 ##' @export
 ##' @rdname odin_dust
 odin_dust_ <- function(x, verbose = NULL, real_t = NULL, int_t = NULL,
-                       workdir = NULL) {
+                       workdir = NULL, gpu = FALSE) {
   options <- odin::odin_options(target = "dust", verbose = verbose,
                                 workdir = workdir)
   ir <- odin::odin_parse_(x, options)
-  odin_dust_wrapper(ir, options, real_t, int_t)
+  odin_dust_wrapper(ir, options, real_t, int_t, gpu)
 }
 
 
@@ -63,7 +65,8 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t) {
   path <- tempfile(fileext = ".cpp")
   writeLines(code, path)
 
-  generator <- dust::dust(path, quiet = !options$verbose, workdir = workdir)
+  generator <- dust::dust(path, quiet = !options$verbose, workdir = workdir,
+                          gpu = gpu)
   if (!("index" %in% names(generator$public_methods))) {
     generator$set("public", "index", odin_dust_index)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -69,10 +69,14 @@ dust_minus_1 <- function(x, protect, data, meta) {
 
 
 cpp_function <- function(return_type, name, args, body) {
+  c(cpp_args(return_type, name, args), paste0("  ", body), "}")
+}
+
+
+cpp_args <- function(return_type, name, args) {
   args_str <- paste(sprintf("%s %s", names(args), unname(args)),
                     collapse = ", ")
-  str <- sprintf("%s %s(%s)", return_type, name, args_str)
-  c(paste0(str, " {"), paste0("  ", body), "}")
+  sprintf("%s %s(%s) {", return_type, name, args_str)
 }
 
 

--- a/inst/support.hpp
+++ b/inst/support.hpp
@@ -209,6 +209,9 @@ std::vector<T> user_get_array_variable(cpp11::list user, const char *name,
 // This is sum with inclusive "from", exclusive "to", following the
 // same function in odin
 template <typename T>
+#ifdef __NVCC__
+__host__ __device__
+#endif
 T odin_sum1(const T * x, size_t from, size_t to) {
   T tot = 0.0;
   for (size_t i = from; i < to; ++i) {

--- a/man/odin_dust.Rd
+++ b/man/odin_dust.Rd
@@ -5,9 +5,23 @@
 \alias{odin_dust_}
 \title{Create a dust odin model}
 \usage{
-odin_dust(x, verbose = NULL, real_t = NULL, int_t = NULL, workdir = NULL)
+odin_dust(
+  x,
+  verbose = NULL,
+  real_t = NULL,
+  int_t = NULL,
+  workdir = NULL,
+  gpu = FALSE
+)
 
-odin_dust_(x, verbose = NULL, real_t = NULL, int_t = NULL, workdir = NULL)
+odin_dust_(
+  x,
+  verbose = NULL,
+  real_t = NULL,
+  int_t = NULL,
+  workdir = NULL,
+  gpu = FALSE
+)
 }
 \arguments{
 \item{x}{Either the name of a file to read, a text string (if
@@ -28,6 +42,8 @@ numbers. Defaults to \code{double}.}
 default we use a new path within the temporary directory. Passed
 to \code{\link{dust}}; a mini package will be created at this
 path.}
+
+\item{gpu}{Use the GPU}
 }
 \description{
 Compile an odin model to work with dust.

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -361,3 +361,15 @@ test_that("specify workdir", {
   expect_true(file.exists(file.path(path, "DESCRIPTION")))
   expect_true(file.exists(file.path(path, "src", "dust.cpp")))
 })
+
+
+test_that("generated code includes gpu decorator", {
+  ir <- odin::odin_parse({
+    initial(x) <- 0
+    update(x) <- runif(x, 1)
+  })
+  options <- odin::odin_options(target = "dust", verbose = FALSE,
+                                workdir = NULL)
+  dat <- generate_dust(ir, options, NULL, NULL)
+  expect_match(dat$class, "__device__", fixed = TRUE, all = FALSE)
+})

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -276,7 +276,7 @@ test_that("NSE interface can accept a symbol and resolve to value", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(path, NULL, NULL, NULL, NULL))
+    list(path, NULL, NULL, NULL, NULL, FALSE))
 })
 
 
@@ -289,7 +289,7 @@ test_that("NSE interface can accept a character vector", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(c("a", "b", "c"), NULL, NULL, NULL, NULL))
+    list(c("a", "b", "c"), NULL, NULL, NULL, NULL, FALSE))
 })
 
 

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -77,19 +77,19 @@ test_that("fold min", {
 
 
 test_that("generate random number code", {
-  meta <- list(dust = list(rng = "rng"))
+  meta <- list(dust = list(rng_state = "rng_state"))
   expect_equal(
     generate_dust_sexp(list("rbinom", "n", "p"), NULL, meta),
-    "rng.rbinom(std::round(n), p)")
+    "dust::distr::rbinom(rng_state, std::round(n), p)")
   expect_equal(
     generate_dust_sexp(list("rpois", "lambda"), NULL, meta),
-    "rng.rpois(lambda)")
+    "dust::distr::rpois(rng_state, lambda)")
   expect_equal(
     generate_dust_sexp(list("runif", "a", "b"), NULL, meta),
-    "rng.runif(a, b)")
+    "dust::distr::runif(rng_state, a, b)")
   expect_equal(
     generate_dust_sexp(list("rnorm", "mu", "sd"), NULL, meta),
-    "rng.rnorm(mu, sd)")
+    "dust::distr::rnorm(rng_state, mu, sd)")
 
   expect_error(
     generate_dust_sexp(list("rchisq", "df"), NULL, meta),


### PR DESCRIPTION
Uses rng state rather than an RNG object. Surprisingly little impact on the generated code, which is nice.

Due to some version leapfrogging this also includes now #23:

This PR generates code that can use dust 0.4.0's GPU capability

The same code will run without problem with dust >= 0.3.0

Fixes #22
Fixes #20 
