### PR TITLE
i24: Set index within the result of info()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -207,12 +207,12 @@ generate_dust_core_info <- function(dat, rewrite) {
   body$add("cpp11::writable::strings nms({%s});",
            paste(dquote(nms), collapse = ", "))
 
-  body$add(generate_dust_core_info_dims(nms, dat, rewrite))
+  body$add(generate_dust_core_info_dim(nms, dat, rewrite))
   body$add(generate_dust_core_info_index(nms, dat, rewrite))
 
   body$add("using namespace cpp11::literals;")
   body$add("return cpp11::writable::list({")
-  body$add('         "dims"_nm = dims,')
+  body$add('         "dim"_nm = dim,')
   body$add('         "index"_nm = index});')
 
   name <- sprintf("dust_info<%s>", dat$config$base)
@@ -221,7 +221,7 @@ generate_dust_core_info <- function(dat, rewrite) {
 }
 
 
-generate_dust_core_info_dims <- function(nms, dat, rewrite) {
+generate_dust_core_info_dim <- function(nms, dat, rewrite) {
   dim1 <- function(x) {
     if (x$rank == 0) {
       dims <- rewrite(1)
@@ -234,10 +234,10 @@ generate_dust_core_info_dims <- function(nms, dat, rewrite) {
   }
 
   dims <- vcapply(dat$data$elements[nms], dim1, USE.NAMES = FALSE)
-  c(sprintf("cpp11::writable::list dims(%d);", length(dims)),
-    sprintf("dims[%d] = cpp11::writable::integers(%s);",
+  c(sprintf("cpp11::writable::list dim(%d);", length(dims)),
+    sprintf("dim[%d] = cpp11::writable::integers(%s);",
             seq_along(dims) - 1L, dims),
-    sprintf("dims.names() = nms;"))
+    sprintf("dim.names() = nms;"))
 }
 
 

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -209,10 +209,13 @@ generate_dust_core_info <- function(dat, rewrite) {
 
   body$add(generate_dust_core_info_dim(nms, dat, rewrite))
   body$add(generate_dust_core_info_index(nms, dat, rewrite))
+  body$add(generate_dust_core_info_len(nms, dat, rewrite))
+
 
   body$add("using namespace cpp11::literals;")
   body$add("return cpp11::writable::list({")
   body$add('         "dim"_nm = dim,')
+  body$add('         "len"_nm = len,')
   body$add('         "index"_nm = index});')
 
   name <- sprintf("dust_info<%s>", dat$config$base)
@@ -256,6 +259,19 @@ generate_dust_core_info_index <- function(nms, dat, rewrite) {
   c(sprintf("cpp11::writable::list index(%d);", length(index)),
     sprintf("index[%d] = %s;", seq_along(index) - 1L, index),
     sprintf("index.names() = nms;"))
+}
+
+
+generate_dust_core_info_len <- function(nms, dat, rewrite) {
+  last <- nms[[length(nms)]]
+  last_offset <- dat$data$variable$contents[[last]]$offset
+  if (dat$data$elements[[last]]$rank == 0) {
+    len <- dust_plus_1(last_offset, rewrite)
+  } else {
+    last_length <- dat$data$elements[[last]]$dimnames$length
+    len <- sprintf("%s + %s", rewrite(last_offset), rewrite(last_length))
+  }
+  sprintf("size_t len = %s;", len)
 }
 
 

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -104,16 +104,15 @@ odin_dust_transform_variables <- function(y) {
     x
   }
 
-  ## TODO: dims might be better as 'dim'
   if (is.matrix(y)) {
     n <- ncol(y)
     Map(function(i, d) set_dim(y[i, , drop = FALSE], c(d, n)),
-        info$index, info$dims)
+        info$index, info$dim)
   } else if (is.array(y)) {
     n <- dim(y)[2:3]
     Map(function(i, d) set_dim(y[i, , , drop = FALSE], c(d, n)),
-        info$index, info$dims)
+        info$index, info$dim)
   } else {
-    Map(function(i, d) set_dim(y[i], d), info$index, info$dims)
+    Map(function(i, d) set_dim(y[i], d), info$index, info$dim)
   }
 }

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -86,6 +86,5 @@ odin_dust_code <- function(dat, real_t, int_t) {
 
 self <- NULL # this will be resolved by R6
 odin_dust_index <- function() {
-  n <- vapply(self$info(), prod, numeric(1))
-  Map(seq.int, to = cumsum(n), by = 1L, length.out = n)
+  self$info()$index
 }

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -67,9 +67,6 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t, gpu) {
 
   generator <- dust::dust(path, quiet = !options$verbose, workdir = workdir,
                           gpu = gpu)
-  if (!("index" %in% names(generator$public_methods))) {
-    generator$set("public", "index", odin_dust_index)
-  }
   if (!("transform_variables" %in% names(generator$public_methods))) {
     generator$set("public", "transform_variables",
                   odin_dust_transform_variables)
@@ -89,11 +86,6 @@ odin_dust_code <- function(dat, real_t, int_t) {
 
 
 self <- NULL # this will be resolved by R6
-odin_dust_index <- function() {
-  self$info()$index
-}
-
-
 odin_dust_transform_variables <- function(y) {
   info <- self$info()
 

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -70,6 +70,10 @@ odin_dust_wrapper <- function(ir, options, real_t, int_t, gpu) {
   if (!("index" %in% names(generator$public_methods))) {
     generator$set("public", "index", odin_dust_index)
   }
+  if (!("transform_variables" %in% names(generator$public_methods))) {
+    generator$set("public", "transform_variables",
+                  odin_dust_transform_variables)
+  }
   generator
 }
 
@@ -87,4 +91,29 @@ odin_dust_code <- function(dat, real_t, int_t) {
 self <- NULL # this will be resolved by R6
 odin_dust_index <- function() {
   self$info()$index
+}
+
+
+odin_dust_transform_variables <- function(y) {
+  info <- self$info()
+
+  set_dim <- function(x, dimx) {
+    if (length(dimx) > 1L) {
+      dim(x) <- dimx
+    }
+    x
+  }
+
+  ## TODO: dims might be better as 'dim'
+  if (is.matrix(y)) {
+    n <- ncol(y)
+    Map(function(i, d) set_dim(y[i, , drop = FALSE], c(d, n)),
+        info$index, info$dims)
+  } else if (is.array(y)) {
+    n <- dim(y)[2:3]
+    Map(function(i, d) set_dim(y[i, , , drop = FALSE], c(d, n)),
+        info$index, info$dims)
+  } else {
+    Map(function(i, d) set_dim(y[i], d), info$index, info$dims)
+  }
 }

--- a/R/package.R
+++ b/R/package.R
@@ -50,11 +50,9 @@ odin_dust_package <- function(path, verbose = NULL, real_t = NULL,
 
   path_dust_r <- file.path(path, "R", "dust.R")
   code_r <- readLines(path_dust_r)
-  code_r_index <- sprintf('%s$set("public", "index", %s)',
-                          nms, deparse_fun(odin_dust_index))
   code_r_transform <- sprintf('%s$set("public", "transform_variables", %s)',
                           nms, deparse_fun(odin_dust_transform_variables))
-  writeLines(c(code_r, header_r, code_r_index, code_r_transform), path_dust_r)
+  writeLines(c(code_r, header_r, code_r_transform), path_dust_r)
 
   path
 }

--- a/R/package.R
+++ b/R/package.R
@@ -52,7 +52,9 @@ odin_dust_package <- function(path, verbose = NULL, real_t = NULL,
   code_r <- readLines(path_dust_r)
   code_r_index <- sprintf('%s$set("public", "index", %s)',
                           nms, deparse_fun(odin_dust_index))
-  writeLines(c(code_r, header_r, code_r_index), path_dust_r)
+  code_r_transform <- sprintf('%s$set("public", "transform_variables", %s)',
+                          nms, deparse_fun(odin_dust_transform_variables))
+  writeLines(c(code_r, header_r, code_r_index, code_r_transform), path_dust_r)
 
   path
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,6 +68,15 @@ dust_minus_1 <- function(x, protect, data, meta) {
 }
 
 
+dust_plus_1 <- function(x, rewrite) {
+  if (is.numeric(x)) {
+    rewrite(x + 1)
+  } else {
+    sprintf("%s + 1", rewrite(x))
+  }
+}
+
+
 cpp_function <- function(return_type, name, args, body) {
   c(cpp_args(return_type, name, args), paste0("  ", body), "}")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,10 +141,10 @@ replace <- function(x, tr) {
 
 deparse_fun <- function(x) {
   stopifnot(is.function(x))
-  str <- deparse(x)
-  if (str[[1]] == "function () ") {
-    str[[2]] <- paste("function()", str[[2]])
-    str <- str[-1]
-  }
-  paste(str, collapse = "\n")
+  str <- paste(sub("\\s+$", "", deparse(x)), collapse = "\n")
+  ## Apply a few fixes:
+  str <- gsub("function (", "function(", str, fixed = TRUE)
+  str <- gsub("\\)\n\\{", ") {", str)
+  str <- gsub("\\}\n\\s*else", "} else", str)
+  str
 }

--- a/inst/support.hpp
+++ b/inst/support.hpp
@@ -219,3 +219,13 @@ T odin_sum1(const T * x, size_t from, size_t to) {
   }
   return tot;
 }
+
+
+inline cpp11::writable::integers integer_sequence(size_t from, size_t len) {
+  cpp11::writable::integers ret(len);
+  int* data = INTEGER(ret);
+  for (size_t i = 0, j = from; i < len; ++i, ++j) {
+    data[i] = j;
+  }
+  return ret;
+}

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -10,7 +10,9 @@ test_that("sir model smoke test", {
   mod <- gen$new(list(I_ini = 10), 0L, n)
   expect_equal(mod$state(), matrix(y0, 3, n))
   expect_equal(mod$step(), 0)
-  expect_identical(mod$info(), list(S = 1L, I = 1L, R = 1L))
+  expect_identical(mod$info(),
+                   list(dims = list(S = 1L, I = 1L, R = 1L),
+                        index = list(S = 1L, I = 2L, R = 3L)))
   expect_equal(mod$index(), list(S = 1L, I = 2L, R = 3L))
 
   nstep <- 200
@@ -39,7 +41,8 @@ test_that("vector handling test", {
   mod <- gen$new(list(), 0L, np)
   expect_equal(mod$state(), matrix(0, ns, np))
   expect_equal(mod$step(), 0)
-  expect_identical(mod$info(), list(x = 3L))
+  expect_identical(mod$info(), list(dims = list(x = 3L),
+                                    index = list(x = seq_len(3))))
   mod$set_index(1L)
 
   y1 <- mod$run(nt)
@@ -61,7 +64,8 @@ test_that("user-vector handling test", {
   x0 <- matrix(runif(10), 2, 5)
 
   mod <- gen$new(list(x0 = x0, r = r), 0, 1)
-  expect_identical(mod$info(), list(x = c(2L, 5L)))
+  expect_identical(mod$info(), list(dims = list(x = c(2L, 5L)),
+                                    index = list(x = seq_len(10))))
 
   expect_equal(mod$state(), matrix(c(x0)))
   expect_equal(mod$step(), 0)
@@ -100,7 +104,8 @@ test_that("multiline array expression", {
     dim(x) <- length(x0)
   }, verbose = FALSE)
   mod <- gen$new(list(), 0, 1)
-  expect_equal(mod$info(), list(y = 1L, x = 10L))
+  expect_equal(mod$info(), list(dims = list(y = 1L, x = 10L),
+                                index = list(y = 1L, x = 2:11)))
   expect_equal(mod$state(), matrix(c(55, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55)))
 })
 
@@ -156,10 +161,13 @@ test_that("Implement sum", {
   cmp <- odin::odin_("examples/sum.R", target = "r", verbose = FALSE)
   yy <- cmp(m)$transform_variables(drop(y))
 
-  expect_mapequal(
+  expect_identical(
     mod$info(),
-    list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L))
-  expect_equal(names(yy)[-1], names(mod$info()))
+    list(
+      dims = list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L),
+      index = list(tot1 = 1L, tot2 = 2L, v1 = 3:7, v2 = 8:14, v3 = 15:19,
+                   v4 = 20:26)))
+  expect_equal(names(yy)[-1], names(mod$info()$dims))
 
   expect_equal(
     mod$index(),

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -12,6 +12,7 @@ test_that("sir model smoke test", {
   expect_equal(mod$step(), 0)
   expect_identical(mod$info(),
                    list(dim = list(S = 1L, I = 1L, R = 1L),
+                        len = 3L,
                         index = list(S = 1L, I = 2L, R = 3L)))
   nstep <- 200
   res <- array(NA_real_, c(3, n, nstep + 1))
@@ -40,6 +41,7 @@ test_that("vector handling test", {
   expect_equal(mod$state(), matrix(0, ns, np))
   expect_equal(mod$step(), 0)
   expect_identical(mod$info(), list(dim = list(x = 3L),
+                                    len = 3L,
                                     index = list(x = seq_len(3))))
   mod$set_index(1L)
 
@@ -63,6 +65,7 @@ test_that("user-vector handling test", {
 
   mod <- gen$new(list(x0 = x0, r = r), 0, 1)
   expect_identical(mod$info(), list(dim = list(x = c(2L, 5L)),
+                                    len = 10L,
                                     index = list(x = seq_len(10))))
 
   expect_equal(mod$state(), matrix(c(x0)))
@@ -103,6 +106,7 @@ test_that("multiline array expression", {
   }, verbose = FALSE)
   mod <- gen$new(list(), 0, 1)
   expect_equal(mod$info(), list(dim = list(y = 1L, x = 10L),
+                                len = 11L,
                                 index = list(y = 1L, x = 2:11)))
   expect_equal(mod$state(), matrix(c(55, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55)))
 })
@@ -164,6 +168,7 @@ test_that("Implement sum", {
     mod$info(),
     list(
       dim = list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L),
+      len = 26L,
       index = list(tot1 = 1L, tot2 = 2L, v1 = 3:7, v2 = 8:14, v3 = 15:19,
                    v4 = 20:26)))
   expect_equal(names(yy), names(mod$info()$dim))

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -11,7 +11,7 @@ test_that("sir model smoke test", {
   expect_equal(mod$state(), matrix(y0, 3, n))
   expect_equal(mod$step(), 0)
   expect_identical(mod$info(),
-                   list(dims = list(S = 1L, I = 1L, R = 1L),
+                   list(dim = list(S = 1L, I = 1L, R = 1L),
                         index = list(S = 1L, I = 2L, R = 3L)))
   expect_equal(mod$index(), list(S = 1L, I = 2L, R = 3L))
 
@@ -41,7 +41,7 @@ test_that("vector handling test", {
   mod <- gen$new(list(), 0L, np)
   expect_equal(mod$state(), matrix(0, ns, np))
   expect_equal(mod$step(), 0)
-  expect_identical(mod$info(), list(dims = list(x = 3L),
+  expect_identical(mod$info(), list(dim = list(x = 3L),
                                     index = list(x = seq_len(3))))
   mod$set_index(1L)
 
@@ -64,7 +64,7 @@ test_that("user-vector handling test", {
   x0 <- matrix(runif(10), 2, 5)
 
   mod <- gen$new(list(x0 = x0, r = r), 0, 1)
-  expect_identical(mod$info(), list(dims = list(x = c(2L, 5L)),
+  expect_identical(mod$info(), list(dim = list(x = c(2L, 5L)),
                                     index = list(x = seq_len(10))))
 
   expect_equal(mod$state(), matrix(c(x0)))
@@ -104,7 +104,7 @@ test_that("multiline array expression", {
     dim(x) <- length(x0)
   }, verbose = FALSE)
   mod <- gen$new(list(), 0, 1)
-  expect_equal(mod$info(), list(dims = list(y = 1L, x = 10L),
+  expect_equal(mod$info(), list(dim = list(y = 1L, x = 10L),
                                 index = list(y = 1L, x = 2:11)))
   expect_equal(mod$state(), matrix(c(55, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55)))
 })
@@ -167,10 +167,10 @@ test_that("Implement sum", {
   expect_identical(
     mod$info(),
     list(
-      dims = list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L),
+      dim = list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L),
       index = list(tot1 = 1L, tot2 = 2L, v1 = 3:7, v2 = 8:14, v3 = 15:19,
                    v4 = 20:26)))
-  expect_equal(names(yy)[-1], names(mod$info()$dims))
+  expect_equal(names(yy)[-1], names(mod$info()$dim))
 
   expect_equal(
     mod$index(),

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -13,8 +13,6 @@ test_that("sir model smoke test", {
   expect_identical(mod$info(),
                    list(dim = list(S = 1L, I = 1L, R = 1L),
                         index = list(S = 1L, I = 2L, R = 3L)))
-  expect_equal(mod$index(), list(S = 1L, I = 2L, R = 3L))
-
   nstep <- 200
   res <- array(NA_real_, c(3, n, nstep + 1))
   res[, , 1] <- y0
@@ -173,10 +171,7 @@ test_that("Implement sum", {
   expect_equal(names(yy)[-1], names(mod$info()$dim))
 
   expect_equal(
-    mod$index(),
-    cmp(m)$transform_variables(seq_len(26))[-1])
-  expect_equal(
-    mod$index(),
+    mod$info()$index,
     mod$transform_variables(seq_len(26)))
 
   expect_equal(yy$tot1, sum(m))

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -155,12 +155,10 @@ test_that("Implement sum", {
 
   mod$run(1)
   y <- mod$state()
-  yy <- mod$transform_variables(y)
+  yy <- mod$transform_variables(drop(y))
 
   cmp <- odin::odin_("examples/sum.R", target = "r", verbose = FALSE)
-  expect_equal(
-    mod$transform_variables(y),
-    cmp(m)$transform_variables(drop(y))[-1])
+  expect_equal(yy, cmp(m)$transform_variables(drop(y))[-1])
 
   expect_identical(
     mod$info(),
@@ -168,7 +166,7 @@ test_that("Implement sum", {
       dim = list(tot1 = 1L, tot2 = 1L, v1 = 5L, v2 = 7L, v3 = 5L, v4 = 7L),
       index = list(tot1 = 1L, tot2 = 2L, v1 = 3:7, v2 = 8:14, v3 = 15:19,
                    v4 = 20:26)))
-  expect_equal(names(yy)[-1], names(mod$info()$dim))
+  expect_equal(names(yy), names(mod$info()$dim))
 
   expect_equal(
     mod$info()$index,
@@ -193,10 +191,10 @@ test_that("sum over variables", {
   mod <- gen$new(list(y0 = a), 0, 1)
   cmp <- odin::odin_("examples/sum2.R", verbose = FALSE)(y0 = a)
 
-  y0 <- mod$transform_variables(mod$state())
+  y0 <- mod$transform_variables(drop(mod$state()))
   expect_equal(y0, cmp$transform_variables(drop(mod$state()))[-1])
 
-  y1 <- mod$transform_variables(mod$run(1))
+  y1 <- mod$transform_variables(drop(mod$run(1)))
   expect_equal(y1, cmp$transform_variables(drop(mod$state()))[-1])
 
   expect_equal(y0$y, a)

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -30,6 +30,9 @@ test_that("validate package", {
   x0 <- matrix(runif(10), 2, 5)
 
   mod <- pkg$env$array$new(list(x0 = x0, r = r), 0, 1)
+  expect_equal(
+    mod$transform_variables(mod$state()),
+    list(x = array(x0, c(2, 5, 1))))
   expect_identical(mod$info(), list(dim = list(x = c(2L, 5L)),
                                     index = list(x = seq_len(10))))
 })

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -30,7 +30,8 @@ test_that("validate package", {
   x0 <- matrix(runif(10), 2, 5)
 
   mod <- pkg$env$array$new(list(x0 = x0, r = r), 0, 1)
-  expect_identical(mod$info(), list(x = c(2L, 5L)))
+  expect_identical(mod$info(), list(dims = list(x = c(2L, 5L)),
+                                    index = list(x = seq_len(10))))
 })
 
 

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -34,6 +34,7 @@ test_that("validate package", {
     mod$transform_variables(mod$state()),
     list(x = array(x0, c(2, 5, 1))))
   expect_identical(mod$info(), list(dim = list(x = c(2L, 5L)),
+                                    len = 10L,
                                     index = list(x = seq_len(10))))
 })
 

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -30,7 +30,7 @@ test_that("validate package", {
   x0 <- matrix(runif(10), 2, 5)
 
   mod <- pkg$env$array$new(list(x0 = x0, r = r), 0, 1)
-  expect_identical(mod$info(), list(dims = list(x = c(2L, 5L)),
+  expect_identical(mod$info(), list(dim = list(x = c(2L, 5L)),
                                     index = list(x = seq_len(10))))
 })
 


### PR DESCRIPTION
This PR updates the generated interface to better suit mcstate: the index variables are always computed, and sit alongside info. I've added a simplified version of transform_variables on top of this, which will help too for complicated models.

~Depends on #21 (as it builds on it)~
Fixes #24 