### PR TITLE
i29: Update to work with new dust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.0.10
+Version: 0.1.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.4.13),
+    dust (>= 0.5.0),
     odin,
     tibble,
     vctrs
@@ -36,4 +36,4 @@ Suggests:
 RoxygenNote: 7.1.0
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust
+    mrc-ide/dust@i106-interleave-rng

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -152,7 +152,7 @@ generate_dust_core_update <- function(eqs, dat, rewrite) {
 
   args <- c("size_t" = dat$meta$time,
             "const real_t *" = dat$meta$state,
-            "dust::rng_state_t<real_t>&" = dat$meta$dust$rng_state,
+            "dust::rng_state_t<real_t>" = dat$meta$dust$rng_state,
             "real_t *" = dat$meta$result)
   c("#ifdef __NVCC__",
     "__device__",


### PR DESCRIPTION
Changes required to work with https://github.com/mrc-ide/dust/pull/107 and the new dust interleaved RNG.

Update the tag reference in DESCRIPTION after the dust PR is merged

Once this is merged, sircovid should be regenerated and the dust version number increased

Fixes #29 