### PR TITLE
Support for sharing constant memory between particles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports:
     cpp11,
     decor,
     dust (>= 0.5.3),
-    odin (>= 1.1.2),
+    odin (>= 1.1.5),
     tibble,
     vctrs
 Suggests:
@@ -37,4 +37,4 @@ RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Remotes:
     mrc-ide/dust,
-    mrc-ide/odin
+    mrc-ide/odin@mrc-2092

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Remotes:
     mrc-ide/dust,
-    mrc-ide/odin@mrc-2092
+    mrc-ide/odin

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin.dust 0.1.7
+
+* Separate internal data into mutable and non-mutable components (#45)
+
 # odin.dust 0.1.6
 
 * Support for vectors of floats (rather than doubles) (#6)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -129,7 +129,7 @@ generate_dust_core_initial <- function(dat, rewrite) {
     data_info <- dat$data$elements[[el$name]]
     if (data_info$rank == 0L) {
       lhs <- sprintf("%s[%s]", dat$meta$state, rewrite(el$offset))
-      sprintf("%s = %s.%s;", lhs, dat$meta$internal, el$initial)
+      sprintf("%s = %s;", lhs, rewrite(el$initial))
     } else {
       src <- rewrite(el$initial)
       sprintf(

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -65,9 +65,13 @@ generate_dust_sexp <- function(x, data, meta, supported) {
     }
     ret
   } else if (is.character(x)) {
-    location <- data$elements[[x]]$location
-    if (!is.null(location) && location == "internal") {
-      sprintf("%s.%s", meta$internal, x)
+    el <- data$elements[[x]]
+    if (!is.null(el$location) && el$location == "internal") {
+      if (el$stage == "time") {
+        sprintf("%s.%s", meta$internal, x)
+      } else {
+        sprintf("%s->%s", meta$dust$shared, x)
+      }
     } else {
       x
     }

--- a/inst/support.hpp
+++ b/inst/support.hpp
@@ -5,6 +5,7 @@
 #include <cpp11/integers.hpp>
 #include <cpp11/list.hpp>
 #include <cpp11/strings.hpp>
+#include <memory>
 #include <vector>
 
 template <typename T>

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -98,17 +98,19 @@ test_that("generate random number code", {
 
 
 test_that("Generate sum code", {
-  internal <- list(internal = "internal")
+  meta <- list(internal = "internal", dust = list(shared = "shared"))
   scalar_int <- function(name) {
     list(name = "dim_m",
          location = "internal",
          storage_type = "int",
+         stage = "constant",
          rank = 0)
   }
   data <- list(elements = list(m = list(name = "m",
                                         location = "internal",
                                         storage_type = "double",
                                         rank = 2,
+                                        stage = "time",
                                         dimnames = list(
                                           length = "dim_m",
                                           dim = c("dim_m_1", "dim_m_2"),
@@ -117,25 +119,25 @@ test_that("Generate sum code", {
                                dim_m_1 = scalar_int("dim_m_1"),
                                dim_m_2 = scalar_int("dim_m_2")))
   expect_equal(
-    generate_dust_sexp(list("sum", "m"), data, internal),
-    "odin_sum1(internal.m.data(), 0, internal.dim_m)")
+    generate_dust_sexp(list("sum", "m"), data, meta),
+    "odin_sum1(internal.m.data(), 0, shared->dim_m)")
 
   expr <- list("sum", "m",
                1L, list("dim", "m", 1),
                2L, list("dim", "m", 2))
   expect_equal(
     generate_dust_sexp(expr, data, internal),
-    paste("odin_sum2(internal.m.data(), 0, internal.dim_m_1,",
-          "1, internal.dim_m_2, internal.dim_m_1)"))
+    paste("odin_sum2(internal.m.data(), 0, shared->dim_m_1,",
+          "1, shared->dim_m_2, shared->dim_m_1)"))
 
   data$elements$m$location <- "variable"
   expect_equal(
-    generate_dust_sexp(list("sum", "m"), data, internal),
-    "odin_sum1(m, 0, internal.dim_m)")
+    generate_dust_sexp(list("sum", "m"), data, meta),
+    "odin_sum1(m, 0, shared->dim_m)")
   expect_equal(
     generate_dust_sexp(expr, data, internal),
-    paste("odin_sum2(m, 0, internal.dim_m_1,",
-          "1, internal.dim_m_2, internal.dim_m_1)"))
+    paste("odin_sum2(m, 0, shared->dim_m_1,",
+          "1, shared->dim_m_2, shared->dim_m_1)"))
 })
 
 

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -126,7 +126,7 @@ test_that("Generate sum code", {
                1L, list("dim", "m", 1),
                2L, list("dim", "m", 2))
   expect_equal(
-    generate_dust_sexp(expr, data, internal),
+    generate_dust_sexp(expr, data, meta),
     paste("odin_sum2(internal.m.data(), 0, shared->dim_m_1,",
           "1, shared->dim_m_2, shared->dim_m_1)"))
 
@@ -135,7 +135,7 @@ test_that("Generate sum code", {
     generate_dust_sexp(list("sum", "m"), data, meta),
     "odin_sum1(m, 0, shared->dim_m)")
   expect_equal(
-    generate_dust_sexp(expr, data, internal),
+    generate_dust_sexp(expr, data, meta),
     paste("odin_sum2(m, 0, shared->dim_m_1,",
           "1, shared->dim_m_2, shared->dim_m_1)"))
 })


### PR DESCRIPTION
Support for sharing constant memory between particles. Creates a shared_ptr to a const struct that all particles can read from; see https://github.com/mrc-ide/dust/pull/124 for the approach

Merge after ~#44 as this PR builds on it, and after~ https://github.com/mrc-ide/odin/pull/215 is merged (update the `DESCRIPTION` to remove the branch pin)

This is somewhat tedious to benchmark, but at least for sircovid this makes no difference at all with identical timings. I'd expect memory usage to be slightly lower, but because we don't go through R's allocator `bench` is not reporting sensible numbers.

Still, hopefully this will prove useful for the GPU work, at least as a proof-of-concept

Fixes #45 