### PR TITLE
Basic implementation of float vectors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.1.5
+Version: 0.1.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # odin.dust 0.1.6
 
-* Support for vectors of floats (rater than doubles) (#6)
+* Support for vectors of floats (rather than doubles) (#6)
 
 # odin.dust 0.1.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin.dust 0.1.6
+
+* Support for vectors of floats (rater than doubles) (#6)
+
 # odin.dust 0.1.5
 
 * Support `as.integer()` in odin code (since odin 1.0.7) (#43)

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -368,6 +368,28 @@ test_that("sir model float test", {
 })
 
 
+test_that("array model float test", {
+  gen_f <- odin_dust_("examples/array.R", real_t = "float", verbose = FALSE)
+  gen_d <- odin_dust_("examples/array.R", real_t = "double", verbose = FALSE)
+
+  r <- matrix(runif(10), 2, 5)
+  x0 <- matrix(runif(10), 2, 5)
+
+  mod_f <- gen_f$new(list(x0 = x0, r = r), 0, 1)
+  mod_d <- gen_d$new(list(x0 = x0, r = r), 0, 1)
+
+  expect_identical(mod_d$state(), matrix(c(x0)))
+  expect_equal(mod_f$state(), mod_d$state(), tolerance = 1e-7)
+  expect_false(identical(mod_f$state(), mod_d$state()))
+
+  y_d <- mod_d$run(1)
+  y_f <- mod_f$run(1)
+  expect_identical(y_d, matrix(c(x0 + r)))
+  expect_equal(y_f, y_d, tolerance = 1e-7)
+  expect_false(identical(y_f, y_d))
+})
+
+
 test_that("specify workdir", {
   path <- tempfile()
   gen <- odin_dust({


### PR DESCRIPTION
This was not that bad in the end; one extra function (`user_get_array_value`) to avoid a partial template specification. We could possibly implement this by a specialisation on `cpp11::as_cpp` but one extra small copy feels ok here.

Lots of details changed in `user_check_value` but the end result is the same.

Fixes #6 