### PR TITLE
Basic modulo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.1.9
+Version: 0.1.10
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin.dust 0.1.10
+
+* Implement modulo (`%%`) operator, which uses `std::fmod`
+
 # odin.dust 0.1.8
 
 * Correct age-structured model in package vignette

--- a/R/common.R
+++ b/R/common.R
@@ -2,7 +2,8 @@ FUNCTIONS_RENAME <- c( # nolint
   gamma = "std::tgamma",
   lgamma = "std::lgamma",
   ceiling = "std::ceil",
-  as.integer = "static_cast<int>")
+  as.integer = "static_cast<int>",
+  "%%" = "std::fmod")
 
 ## Basically odin's FUNCTIONS_MATH:
 FUNCTIONS_STDLIB <- c( # nolint

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -446,7 +446,7 @@ test_that("allow custom C++ code", {
 
 
 ## This is a little less good than the version in odin because that
-## implements s specific interpretation of modulo in the presence of
+## implements a specific interpretation of modulo in the presence of
 ## negative divisors
 test_that("modulo works", {
   gen <- odin_dust({

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -443,3 +443,25 @@ test_that("allow custom C++ code", {
   y <- mod$run(1)
   expect_equal(y[, 1], cumsum(x))
 })
+
+
+## This is a little less good than the version in odin because that
+## implements s specific interpretation of modulo in the presence of
+## negative divisors
+test_that("modulo works", {
+  gen <- odin_dust({
+    a <- user()
+    b <- user(integer = TRUE)
+    initial(x) <- 0
+    update(x) <- step %% a
+    initial(y) <- 0
+    update(y) <- step %% b
+    initial(z) <- 0
+    update(z) <- step
+  }, verbose = TRUE)
+  mod <- gen$new(list(a = 4, b = 5), 0, 1)
+  y <- drop(dust::dust_iterate(mod, 0:10))
+  yy <- mod$transform_variables(y)
+  expect_equal(yy$x, yy$z %% 4)
+  expect_equal(yy$y, yy$z %% 5)
+})

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -154,4 +154,7 @@ test_that("renames", {
   expect_equal(
     generate_dust_sexp(list("as.integer", "x"), NULL, NULL, NULL),
     "static_cast<int>(x)")
+  expect_equal(
+    generate_dust_sexp(list("%%", "x", "y"), NULL, NULL, NULL),
+    "std::fmod(x, y)")
 })


### PR DESCRIPTION
Implements `a %% b` by translating to `std::fmod(a, b)`

We might want to extend this to be R's fancy modulo which differs for negative values but that's not needed right now and runs into some issues with needing to change the order of includes

Fixes #52 