### PR TITLE
Correct and test compiled comparison in package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.1.11
+Version: 0.1.12
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,6 @@ Imports:
     cpp11,
     decor,
     dust (>= 0.6.1),
-    glue,
     odin (>= 1.1.7),
     tibble,
     vctrs

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -395,6 +395,10 @@ generate_dust_include <- function(include) {
 
 
 read_compare_dust <- function(filename) {
+  if (!file.exists(filename)) {
+    stop(sprintf("Did not find a file '%s' (relative to odin source)",
+                 filename))
+  }
   dat <- decor::cpp_decorations(files = filename)
   i_fn <- dat$decoration == "odin.dust::compare_function"
   if (sum(i_fn) == 0L) {

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -78,7 +78,7 @@ generate_dust_core_class <- function(eqs, dat, rewrite) {
   ret$add(paste0("  ", size))
   ret$add(paste0("  ", initial))
   ret$add(paste0("  ", update))
-  ret$add(sprintf("%s   ", compare)) # ensures we don't add trailing whitespace
+  ret$add(sprintf("  %s", compare)) # ensures we don't add trailing whitespace
   ret$add("private:")
   ret$add("  std::shared_ptr<const shared_t> %s;", dat$meta$dust$shared)
   ret$add("  internal_t %s;", dat$meta$internal)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -548,8 +548,10 @@ generate_dust_core_data <- function(dat) {
   if (is.null(dat$compare)) {
     return(NULL)
   }
-  contents <- sprintf('    cpp11::as_cpp<%s>(data["%s"])',
-                      unname(dat$compare$data), names(dat$compare$data))
+  contents <- sprintf('    cpp11::as_cpp<%s>(data["%s"])%s',
+                      unname(dat$compare$data),
+                      names(dat$compare$data),
+                      rep(c(",", ""), c(length(dat$compare$data) - 1, 1)))
   body <- c(sprintf("return %s::data_t{", dat$config$base),
             contents,
             "  };")

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -562,28 +562,6 @@ generate_dust_core_data <- function(dat) {
 }
 
 
-odin_variable_transformer <- function(dat, rewrite) {
-  err <- new.env(parent = emptyenv())
-  transform <- function(text, envir) {
-    text <- trimws(text)
-    ans <- rewrite(text)
-    if (ans == text) {
-      el <- dat$data$variable$contents[[text]]
-      if (is.null(el)) {
-        err[[text]] <- TRUE
-      } else {
-        ans <- sprintf("%s[%s]", dat$meta$state, rewrite(el$offset))
-      }
-    }
-    ans
-  }
-  errors <- function() {
-    names(err)
-  }
-  list(transform = transform, errors = errors)
-}
-
-
 ## It would be really nice to use glue for this but we can't disable
 ## escaping whcih means that a '))' becomes ')' which results in
 ## broken code. This approach is pretty ugly but should do the trick

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -397,8 +397,13 @@ generate_dust_include <- function(include) {
 read_compare_dust <- function(filename) {
   dat <- decor::cpp_decorations(files = filename)
   i_fn <- dat$decoration == "odin.dust::compare_function"
-  if (sum(i_fn) != 1L) {
-    stop("Expected one decoration '[[odin.dust::compare_function]]'")
+  if (sum(i_fn) == 0L) {
+    stop("Did not find a decoration '[[odin.dust::compare_function]]'")
+  }
+  if (sum(i_fn) > 1L) {
+    stop(sprintf(
+      "Expected one decoration '[[odin.dust::compare_function]]' but found %d",
+      sum(i_fn)))
   }
   ctx <- dat$context[[which(i_fn)]]
   ## There's a long message here because this is a trick:

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -41,7 +41,12 @@ odin_dust <- function(x, verbose = NULL, real_t = NULL, workdir = NULL) {
 odin_dust_ <- function(x, verbose = NULL, real_t = NULL, workdir = NULL) {
   options <- odin_dust_options(verbose, workdir)
   ir <- odin::odin_parse_(x, options)
-  odin_dust_wrapper(ir, options, real_t)
+  if (is.character(x) && length(x) == 1L && file.exists(x)) {
+    srcdir <- dirname(x)
+  } else {
+    srcdir <- "."
+  }
+  odin_dust_wrapper(ir, options, real_t, srcdir)
 }
 
 
@@ -54,8 +59,10 @@ odin_dust_options <- function(verbose, workdir) {
 }
 
 
-odin_dust_wrapper <- function(ir, options, real_t) {
-  dat <- generate_dust(ir, options, real_t)
+odin_dust_wrapper <- function(ir, options, real_t, srcdir) {
+  dat <- with_dir(
+    srcdir,
+    generate_dust(ir, options, real_t))
   code <- odin_dust_code(dat)
 
   path <- tempfile(fileext = ".cpp")

--- a/R/package.R
+++ b/R/package.R
@@ -33,7 +33,9 @@ odin_dust_package <- function(path, verbose = NULL, real_t = NULL) {
 
   for (f in filenames) {
     ir <- odin::odin_parse_(f, options)
-    dat <- generate_dust(ir, options, real_t)
+    dat <- with_dir(
+      dirname(f),
+      generate_dust(ir, options, real_t))
     code <- odin_dust_code(dat)
     dest <- file.path(path, "inst", "dust", sub(re_r, ".cpp", basename(f)))
     if (file.exists(dest)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -151,3 +151,10 @@ deparse_fun <- function(x) {
 deparse_str <- function(x) {
   paste(deparse(x), collapse = "\n")
 }
+
+
+with_dir <- function(path, code) {
+  owd <- setwd(path)
+  on.exit(setwd(owd))
+  force(code)
+}

--- a/tests/testthat/examples/compare_simple.cpp
+++ b/tests/testthat/examples/compare_simple.cpp
@@ -1,4 +1,5 @@
 // [[odin.dust::compare_data(observed = double)]]
+// [[odin.dust::compare_data(another = int)]]
 // [[odin.dust::compare_function]]
 template <typename T>
 typename T::real_t compare(const typename T::real_t * state,

--- a/tests/testthat/examples/compare_simple.cpp
+++ b/tests/testthat/examples/compare_simple.cpp
@@ -7,6 +7,6 @@ typename T::real_t compare(const typename T::real_t * state,
                            const typename T::internal_t internal,
                            std::shared_ptr<const typename T::shared_t> shared,
                            dust::rng_state_t<typename T::real_t>& rng_state) {
-  // Here, odin(y) refers to state[0] and scale refers to shared->scale
+  // Here, 'y' refers to state[0] and 'scale' refers to shared->scale
   return (odin(y) - data.observed) / odin(scale);
 }

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -221,3 +221,21 @@ test_that("Sensible error messages on substitution failure", {
     err$message,
     "- scale: line 11")
 })
+
+
+test_that("Sensible error message when files are not found in other dir", {
+  path <- tempfile()
+  dir.create(path)
+  filename <- file.path(path, "code.R")
+
+  code <- c("initial(y) <- 0",
+            "update(y) <- y + rnorm(0, 1)",
+            "scale <- user(1) # ignore.unused",
+            'config(compare) <- "examples/compare_simple.cpp"')
+  writeLines(code, filename)
+
+  expect_error(
+    odin_dust(filename),
+    "Did not find a file 'examples/compare_simple.cpp' (relative to odin",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -25,7 +25,14 @@ test_that("Can error if correct metadata not found", {
   writeLines(character(), path)
   expect_error(
     read_compare_dust(path),
-    "Expected one decoration '[[odin.dust::compare_function]]'",
+    "Did not find a decoration '[[odin.dust::compare_function]]'",
+    fixed = TRUE)
+
+  path <- tempfile()
+  writeLines(c(fn[[1]], fn), path)
+  expect_error(
+    read_compare_dust(path),
+    "Expected one decoration '[[odin.dust::compare_function]]' but found 2",
     fixed = TRUE)
 
   writeLines(fn, path)

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -5,7 +5,7 @@ read_compare_dust("examples/compare_simple.cpp")
 test_that("Can parse compare metadata", {
   res <- read_compare_dust("examples/compare_simple.cpp")
   expect_equal(res$function_name, "compare")
-  expect_equal(res$data, c(observed = "double"))
+  expect_equal(res$data, c(observed = "double", another = "int"))
 })
 
 
@@ -88,7 +88,9 @@ test_that("Basic compare", {
 
   t <- seq(0, 20, by = 2)
   d <- dust::dust_data(
-    data.frame(step = t, observed = runif(length(t), 0, sqrt(t))))
+    data.frame(step = t,
+               observed = runif(length(t), 0, sqrt(t)),
+               another = 0L))
   mod$set_data(d)
   expect_equal(mod$compare_data(), rep(0, np))
 
@@ -217,5 +219,5 @@ test_that("Sensible error messages on substitution failure", {
     "Did not find odin variables when reading 'examples/compare_simple.cpp'")
   expect_match(
     err$message,
-    "- scale: line 10")
+    "- scale: line 11")
 })

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -183,3 +183,15 @@ test_that("Only one compare block allowed", {
     "Only one 'config(compare)' statement is allowed",
     fixed = TRUE)
 })
+
+test_that("Find correct compare file", {
+  expect_error(
+    odin_dust(
+      c("initial(y) <- 0",
+        "update(y) <- y + rnorm(0, 1)",
+        "scale <- user(1) # ignore.unused",
+        'config(compare) <- "examples/compare-simple.cpp"'),
+      verbose = FALSE),
+    "Did not find a file 'examples/compare-simple.cpp' (relative to odin",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -458,7 +458,7 @@ test_that("modulo works", {
     update(y) <- step %% b
     initial(z) <- 0
     update(z) <- step
-  }, verbose = TRUE)
+  }, verbose = FALSE)
   mod <- gen$new(list(a = 4, b = 5), 0, 1)
   y <- drop(dust::dust_iterate(mod, 0:10))
   yy <- mod$transform_variables(y)

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -152,7 +152,9 @@ test_that("use compiled compare function in package", {
 
   t <- seq(0, 20, by = 2)
   d <- dust::dust_data(
-    data.frame(step = t, observed = runif(length(t), 0, sqrt(t))))
+    data.frame(step = t,
+               observed = runif(length(t), 0, sqrt(t)),
+               another = 1L))
   mod$set_data(d)
 
   y <- mod$run(1)

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -137,6 +137,13 @@ test_that("use compiled compare function in package", {
 
   odin_dust_package(path)
 
+  ## No whitespace in generated files:
+  files <- list.files(path, recursive = TRUE, all.files = TRUE,
+                      include.dirs = FALSE, no.. = TRUE,
+                      full.names = TRUE)
+  txt <- unlist(lapply(files, readLines))
+  expect_false(any(grepl("\\s+$", txt)))
+
   pkg <- pkgload::load_all(path, quiet = TRUE)
 
   np <- 10


### PR DESCRIPTION
In trying to wire this up with sircovid it turned out I'd failed to test (or implement correctly) the package interface to this.

This has become a bit of an omnibus PR with a number of bugs and unpleasantnesses fixed:

* generated code no longer includes whitespace (in C++), with test
* moved away from glue for the odin substitution because it's escape behaviour mangled code (`))` became `)` because it was an exactly-doubled closing marker)
* generating the data struct constructor was broken if it contained more than one element
* odin_dust() did not work with compare function when the source was in a subdirectory

Fixes #55 