### PR TITLE
Fix typo in sir_models.Rmd

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.1.13
+Version: 0.1.14
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/vignettes/sir_models.Rmd
+++ b/vignettes/sir_models.Rmd
@@ -35,7 +35,7 @@ Discretising this model in time steps of width $dt$ gives the following update e
 $$\begin{align*}
 S_{t+1} &= S_t - n_{SI} \\
 I_{t+1} &= I_t + n_{SI} - n_{IR} \\
-R_{t+1} &= R_t - n_{IR}
+R_{t+1} &= R_t + n_{IR}
 \end{align*}$$
 
 where


### PR DESCRIPTION
Fixed typo from `-` to `+` in `R_{t+1}` of `sir_models.Rmd`