### PR TITLE
Generate code for models on gpu

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.1.14
+Version: 0.1.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,5 +36,5 @@ Suggests:
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust@i115-interleave,
+    mrc-ide/dust,
     mrc-ide/odin

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.7.0),
+    dust (>= 0.7.10),
     odin (>= 1.1.7),
     tibble,
     vctrs
@@ -36,5 +36,5 @@ Suggests:
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust,
+    mrc-ide/dust@i115-interleave,
     mrc-ide/odin

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin.dust 0.1.15
+
+* Start implementing dust gpu support by generating interleaved update function, optionally (#37)
+
 # odin.dust 0.1.11
 
 * Support for dust `compare` functions (#51)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -642,9 +642,11 @@ generate_dust_gpu <- function(eqs, dat, rewrite) {
 
 
 generate_dust_gpu_declaration <- function(dat, rewrite) {
-  c("template <>",
-    sprintf("struct dust::has_gpu_support<%s> : std::true_type {};",
-            dat$config$base))
+  c("namespace dust {",
+    "template <>",
+    sprintf("struct has_gpu_support<%s> : std::true_type {};",
+            dat$config$base),
+    "}")
 }
 
 

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -35,7 +35,7 @@ generate_dust <- function(ir, options, real_t = NULL, gpu = FALSE) {
   used <- unique(unlist(lapply(dat$equations, function(x)
     x$depends$functions), FALSE, FALSE))
   support <- NULL
-  if ("odin_sum" %in% used) {
+  if (any(c("sum", "odin_sum") %in% used)) {
     ranks <- sort(unique(viapply(dat$data$elements, "[[", "rank")))
     ranks <- ranks[ranks > 0]
     if (length(ranks) > 0L) {

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -1,5 +1,10 @@
-generate_dust_equations <- function(dat, rewrite) {
-  lapply(dat$equations, generate_dust_equation, dat, rewrite)
+generate_dust_equations <- function(dat, rewrite, which = NULL) {
+  if (is.null(which)) {
+    eqs <- dat$equations
+  } else {
+    eqs <- dat$equations[which]
+  }
+  lapply(eqs, generate_dust_equation, dat, rewrite)
 }
 
 

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -88,15 +88,16 @@ generate_dust_sexp <- function(x, data, meta, supported, gpu) {
 generate_dust_sexp_sum <- function(args, data, meta, supported, gpu) {
   target <- generate_dust_sexp(args[[1]], data, meta, supported, gpu)
   data_info <- data$elements[[args[[1]]]]
+  type <- if (data_info$storage_type == "double") "real_t" else "int"
 
-  if (data_info$location == "internal") {
+  if (data_info$location == "internal" && !gpu) {
     target <- sprintf("%s.data()", target)
   }
 
   if (length(args) == 1L) {
     len <- generate_dust_sexp(data_info$dimnames$length, data, meta,
                               supported, gpu)
-    sprintf("odin_sum1(%s, 0, %s)", target, len)
+    sprintf("odin_sum1<%s>(%s, 0, %s)", type, target, len)
   } else {
     i <- seq(2, length(args), by = 2)
 
@@ -109,6 +110,6 @@ generate_dust_sexp_sum <- function(args, data, meta, supported, gpu) {
     values[[1]] <- target
     arg_str <- paste(values, collapse = ", ")
 
-    sprintf("odin_sum%d(%s)", length(i), arg_str)
+    sprintf("odin_sum%d<%s>(%s)", length(i), type, arg_str)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -158,3 +158,9 @@ with_dir <- function(path, code) {
   on.exit(setwd(owd))
   force(code)
 }
+
+
+set_names <- function(x, nms) {
+  names(x) <- nms
+  x
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,15 +41,15 @@ squote <- function(...) {
 }
 
 
-dust_array_access <- function(target, index, data, meta, supported) {
+dust_array_access <- function(target, index, data, meta, supported, gpu) {
   mult <- data$elements[[target]]$dimnames$mult
 
   f <- function(i) {
-    index_i <- dust_minus_1(index[[i]], i > 1, data, meta, supported)
+    index_i <- dust_minus_1(index[[i]], i > 1, data, meta, supported, gpu)
     if (i == 1) {
       index_i
     } else {
-      mult_i <- generate_dust_sexp(mult[[i]], data, meta, supported)
+      mult_i <- generate_dust_sexp(mult[[i]], data, meta, supported, gpu)
       sprintf("%s * %s", mult_i, index_i)
     }
   }
@@ -58,11 +58,11 @@ dust_array_access <- function(target, index, data, meta, supported) {
 }
 
 
-dust_minus_1 <- function(x, protect, data, meta, supported) {
+dust_minus_1 <- function(x, protect, data, meta, supported, gpu) {
   if (is.numeric(x)) {
-    generate_dust_sexp(x - 1L, data, meta, supported)
+    generate_dust_sexp(x - 1L, data, meta, supported, gpu)
   } else {
-    x_expr <- generate_dust_sexp(x, data, meta, supported)
+    x_expr <- generate_dust_sexp(x, data, meta, supported, gpu)
     sprintf(if (protect) "(%s - 1)" else "%s - 1", x_expr)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -103,15 +103,15 @@ generate_dust_support_sum <- function(rank) {
   if (rank == 1) {
     list(name = "odin_sum1",
          declaration = c(
-           "template <typename T>",
-           "T odin_sum1(const T * x, size_t from, size_t to);"),
+           "template <typename real_t, typename container>",
+           "real_t odin_sum1(const container x, size_t from, size_t to);"),
          definition = NULL)
   } else {
     ## There are a series of substitutions that need to be made here,
     ## all of which are literal
-    tr <- c("double*" = "const real_t *",
+    tr <- c("double*" = "const container",
             "double" = "real_t")
-    head <- "template <typename real_t>"
+    head <- "template <typename real_t, typename container>"
     ret <- lapply(odin:::generate_c_support_sum(rank), replace, tr)
     ret$declaration <- c(head, ret$declaration)
     ret$definition <- c(head, ret$definition)

--- a/inst/support.hpp
+++ b/inst/support.hpp
@@ -194,18 +194,14 @@ inline std::vector<float> user_get_array_value(cpp11::sexp x, const char * name,
 
 // This is sum with inclusive "from", exclusive "to", following the
 // same function in odin
-template <typename T>
-#ifdef __NVCC__
-__host__ __device__
-#endif
-T odin_sum1(const T * x, size_t from, size_t to) {
-  T tot = 0.0;
+template <typename real_t, typename container>
+real_t odin_sum1(const container x, size_t from, size_t to) {
+  real_t tot = 0.0;
   for (size_t i = from; i < to; ++i) {
     tot += x[i];
   }
   return tot;
 }
-
 
 inline cpp11::writable::integers integer_sequence(size_t from, size_t len) {
   cpp11::writable::integers ret(len);

--- a/man/odin_dust.Rd
+++ b/man/odin_dust.Rd
@@ -5,9 +5,9 @@
 \alias{odin_dust_}
 \title{Create a dust odin model}
 \usage{
-odin_dust(x, verbose = NULL, real_t = NULL, workdir = NULL)
+odin_dust(x, verbose = NULL, real_t = NULL, workdir = NULL, gpu = FALSE)
 
-odin_dust_(x, verbose = NULL, real_t = NULL, workdir = NULL)
+odin_dust_(x, verbose = NULL, real_t = NULL, workdir = NULL, gpu = FALSE)
 }
 \arguments{
 \item{x}{Either the name of a file to read, a text string (if
@@ -25,6 +25,11 @@ numbers. Defaults to \code{double}.}
 default we use a new path within the temporary directory. Passed
 to \code{\link{dust}}; a mini package will be created at this
 path.}
+
+\item{gpu}{**Experimental!** Generate support code for dust's GPU
+support. This is currently incomplete and does not actually run
+on a GPU, but once it does, this argument will help. Currently
+not supported within package code.}
 }
 \description{
 Compile an odin model to work with dust.

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -1,0 +1,20 @@
+context("gpu")
+
+test_that("Can generate interleaved interface for basic model", {
+  ## This is logically the same as 'variable' in dust, though the code
+  ## generated is slightly different.
+  gen <- odin_dust({
+    len <- user(integer = TRUE)
+    mean <- user(0)
+    sd <- user(1)
+    initial(x[]) <- i
+    update(x[]) <- rnorm(x[i] + mean, sd)
+    dim(x) <- len
+  }, gpu = TRUE, verbose = FALSE)
+
+  mod1 <- gen$new(list(len = 10), 0, 10, seed = 1L)
+  mod2 <- gen$new(list(len = 10), 0, 10, seed = 1L)
+  expect_identical(
+    mod1$run(10),
+    mod2$run(10))
+})

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -40,3 +40,51 @@ test_that("Can generate gpu code with internal storage", {
     mod1$run(10),
     mod2$run(10, device = TRUE))
 })
+
+
+## Sums of time varying things are important, so we use a slighty
+## modified version of examples/sum.R that forces 'm' to be stored in
+## ther internal data (rather than constant shared data)
+test_that("Can run basic sums on device", {
+  gen <- odin_dust({
+    m_user[, ] <- user()
+    dim(m_user) <- user()
+
+    m[, ] <- m_user[i, j] + step * 0
+    dim(m) <- c(dim(m_user, 1), dim(m_user, 2))
+
+    update(v1[]) <- sum(m[i, ])
+    dim(v1) <- dim(m, 1)
+    update(v2[]) <- sum(m[, i])
+    dim(v2) <- dim(m, 2)
+
+    update(v3[]) <- sum(m[i, 2:4])
+    dim(v3) <- length(v1)
+    update(v4[]) <- sum(m[2:4, i])
+    dim(v4) <- length(v2)
+
+    update(tot1) <- sum(m)
+    update(tot2) <- sum(m[, ])
+    update(tot3) <- sum(m_user)
+    update(tot4) <- sum(m_user[, ])
+
+    initial(v1[]) <- 0
+    initial(v2[]) <- 0
+    initial(v3[]) <- 0
+    initial(v4[]) <- 0
+    initial(tot1) <- 0
+    initial(tot2) <- 0
+    initial(tot3) <- 0
+    initial(tot4) <- 0
+  }, gpu = TRUE, verbose = FALSE)
+
+  nr <- 5
+  nc <- 7
+  m <- matrix(runif(nr * nc), nr, nc)
+  mod1 <- gen$new(list(m_user = m), 0, 1)
+  mod2 <- gen$new(list(m_user = m), 0, 1)
+
+  y1 <- mod1$transform_variables(drop(mod1$run(1)))
+  y2 <- mod1$transform_variables(drop(mod2$run(1, device = TRUE)))
+  expect_identical(y1, y2)
+})

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -92,8 +92,8 @@ test_that("Can run basic sums on device", {
 
 ## This is more strictly a dust check
 test_that("gpu and gpu-free versions do not interfere in cache", {
-  gen1 <- odin_dust_("examples/sir.R", verbose = TRUE)
-  gen2 <- odin_dust_("examples/sir.R", verbose = TRUE, gpu = TRUE)
+  gen1 <- odin_dust_("examples/sir.R", verbose = FALSE)
+  gen2 <- odin_dust_("examples/sir.R", verbose = FALSE, gpu = TRUE)
   expect_error(
     gen1$new(list(I_ini = 1), 0, 1)$run(0, device = TRUE),
     "GPU support not enabled for this object")

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -88,3 +88,15 @@ test_that("Can run basic sums on device", {
   y2 <- mod1$transform_variables(drop(mod2$run(1, device = TRUE)))
   expect_identical(y1, y2)
 })
+
+
+## This is more strictly a dust check
+test_that("gpu and gpu-free versions do not interfere in cache", {
+  gen1 <- odin_dust_("examples/sir.R", verbose = TRUE)
+  gen2 <- odin_dust_("examples/sir.R", verbose = TRUE, gpu = TRUE)
+  expect_error(
+    gen1$new(list(I_ini = 1), 0, 1)$run(0, device = TRUE),
+    "GPU support not enabled for this object")
+  expect_silent(
+    gen2$new(list(I_ini = 1), 0, 1)$run(0, device = TRUE))
+})

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -16,5 +16,27 @@ test_that("Can generate interleaved interface for basic model", {
   mod2 <- gen$new(list(len = 10), 0, 10, seed = 1L)
   expect_identical(
     mod1$run(10),
-    mod2$run(10))
+    mod2$run(10, device = TRUE))
+})
+
+
+test_that("Can generate gpu code with internal storage", {
+  gen <- odin_dust({
+    len <- user(integer = TRUE)
+    mean <- user(0)
+    sd <- user(1)
+    x[] <- rnorm(mean, sd)
+    y[] <- rnorm(mean, sd)
+    initial(z[]) <- 0
+    update(z[]) <- z[i] + x[i] / y[i]
+    dim(x) <- len
+    dim(y) <- len
+    dim(z) <- len
+  }, gpu = TRUE, verbose = FALSE)
+
+  mod1 <- gen$new(list(len = 10), 0, 10, seed = 1L)
+  mod2 <- gen$new(list(len = 10), 0, 10, seed = 1L)
+  expect_identical(
+    mod1$run(10),
+    mod2$run(10, device = TRUE))
 })

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -420,7 +420,7 @@ test_that("transform_variables works with all 3 state options", {
                list(x = array(rep(x0, 2), c(dim(x0), 2))))
 
   ## hard
-  y <- dust::dust_iterate(mod, c(0, 0, 0))
+  y <- mod$simulate(c(0, 0, 0))
   yy <- mod$transform_variables(y)
   expect_equal(yy$x[, , 1, 1], x0)
   expect_equal(yy$x, array(rep(x0, 6), c(dim(x0), 2, 3)))
@@ -460,7 +460,7 @@ test_that("modulo works", {
     update(z) <- step
   }, verbose = FALSE)
   mod <- gen$new(list(a = 4, b = 5), 0, 1)
-  y <- drop(dust::dust_iterate(mod, 0:10))
+  y <- mod$simulate(0:10)
   yy <- mod$transform_variables(y)
   expect_equal(yy$x, yy$z %% 4)
   expect_equal(yy$y, yy$z %% 5)

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -465,3 +465,25 @@ test_that("modulo works", {
   expect_equal(yy$x, yy$z %% 4)
   expect_equal(yy$y, yy$z %% 5)
 })
+
+
+## See #63; if this compiles it's certainly correct as it was an error
+## in inclusion of the correct support function. However we check the
+## result anyway.
+test_that("Detect sum corner case", {
+  gen <- odin_dust({
+    len <- user(integer = TRUE)
+    mean <- user(0)
+    sd <- user(1)
+    x[] <- rnorm(mean, sd)
+    initial(z) <- 0
+    update(z) <- z + sum(x)
+    dim(x) <- len
+  }, verbose = FALSE)
+
+  mod <- gen$new(list(len = 10), 0, 1L, seed = 1L)
+  y <- mod$simulate(0:5)
+  rng <- dust::dust_rng$new(1, seed = 1L)
+  m <- matrix(rng$norm_rand(10 * 5), 10, 5)
+  expect_equal(drop(y), cumsum(c(0, colSums(m))))
+})

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -302,7 +302,7 @@ test_that("NSE interface can accept a symbol and resolve to value", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(path, NULL, NULL, NULL))
+    list(path, NULL, NULL, NULL, FALSE))
 })
 
 
@@ -315,7 +315,7 @@ test_that("NSE interface can accept a character vector", {
   mockery::expect_called(mock_target, 1)
   expect_equal(
     mockery::mock_args(mock_target)[[1]],
-    list(c("a", "b", "c"), NULL, NULL, NULL))
+    list(c("a", "b", "c"), NULL, NULL, NULL, FALSE))
 })
 
 

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -119,24 +119,27 @@ test_that("Generate sum code", {
                                dim_m_1 = scalar_int("dim_m_1"),
                                dim_m_2 = scalar_int("dim_m_2")))
   expect_equal(
-    generate_dust_sexp(list("sum", "m"), data, meta),
-    "odin_sum1(internal.m.data(), 0, shared->dim_m)")
+    generate_dust_sexp(list("sum", "m"), data, meta, NULL, FALSE),
+    "odin_sum1<real_t>(internal.m.data(), 0, shared->dim_m)")
+  expect_equal(
+    generate_dust_sexp(list("sum", "m"), data, meta, NULL, TRUE),
+    "odin_sum1<real_t>(m, 0, shared->dim_m)")
 
   expr <- list("sum", "m",
                1L, list("dim", "m", 1),
                2L, list("dim", "m", 2))
   expect_equal(
-    generate_dust_sexp(expr, data, meta),
-    paste("odin_sum2(internal.m.data(), 0, shared->dim_m_1,",
+    generate_dust_sexp(expr, data, meta, NULL, FALSE),
+    paste("odin_sum2<real_t>(internal.m.data(), 0, shared->dim_m_1,",
           "1, shared->dim_m_2, shared->dim_m_1)"))
 
   data$elements$m$location <- "variable"
   expect_equal(
-    generate_dust_sexp(list("sum", "m"), data, meta),
-    "odin_sum1(m, 0, shared->dim_m)")
+    generate_dust_sexp(list("sum", "m"), data, meta, NULL, FALSE),
+    "odin_sum1<real_t>(m, 0, shared->dim_m)")
   expect_equal(
-    generate_dust_sexp(expr, data, meta),
-    paste("odin_sum2(m, 0, shared->dim_m_1,",
+    generate_dust_sexp(expr, data, meta, NULL, FALSE),
+    paste("odin_sum2<real_t>(m, 0, shared->dim_m_1,",
           "1, shared->dim_m_2, shared->dim_m_1)"))
 })
 


### PR DESCRIPTION
Uses the support introduced in https://github.com/mrc-ide/dust/pull/164 which is incomplete. This PR lets us generate fairly complicated update functions (theoretically that of sircovid?) which will make further development of the gpu code much easier.

Changes are relatively minor here:

* light rewriting of the equations involved in the update as we've moved a few things in internal
* some changes to the sum functions - note explicit specification of the return type now as the container type and value type are now unrelated
* additional argument to the main odin_dust function to turn on this support

It's not enabled by default, and not enabled at all in packages; that will give us freedom to tinker with the toolchain in dust