### PR TITLE
Formally remove output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -191,10 +191,8 @@ generate_dust_core_initial <- function(dat, rewrite) {
 
 
 generate_dust_core_update <- function(eqs, dat, rewrite) {
-  variables <- union(dat$components$rhs$variables,
-                     dat$components$output$variables)
-  equations <- union(dat$components$rhs$equations,
-                     dat$components$output$equations)
+  variables <- dat$components$rhs$variables
+  equations <- dat$components$rhs$equations
 
   unpack <- lapply(variables, dust_unpack_variable,
                    dat, dat$meta$state, rewrite)

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -32,8 +32,7 @@ generate_dust_equation_scalar <- function(eq, data_info, dat, rewrite) {
     lhs <- rewrite(eq$lhs)
   } else {
     offset <- dat$data[[location]]$contents[[data_info$name]]$offset
-    storage <- if (location == "variable") dat$meta$result else dat$meta$output
-    lhs <- sprintf("%s[%s]", storage, rewrite(offset))
+    lhs <- sprintf("%s[%s]", dat$meta$result, rewrite(offset))
   }
   rhs <- rewrite(eq$rhs$value)
   sprintf("%s = %s;", lhs, rhs)
@@ -118,8 +117,7 @@ generate_dust_equation_array_lhs <- function(eq, data_info, dat, rewrite) {
     lhs <- sprintf("%s[%s]", rewrite(data_info$name), pos)
   } else {
     offset <- rewrite(dat$data[[location]]$contents[[data_info$name]]$offset)
-    storage <- if (location == "variable") dat$meta$result else dat$meta$output
-    lhs <- sprintf("%s[%s + %s]", storage, offset, pos)
+    lhs <- sprintf("%s[%s + %s]", dat$meta$result, offset, pos)
   }
 
   lhs

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -487,3 +487,14 @@ test_that("Detect sum corner case", {
   m <- matrix(rng$norm_rand(10 * 5), 10, 5)
   expect_equal(drop(y), cumsum(c(0, colSums(m))))
 })
+
+
+test_that("disallow output()", {
+  expect_error(
+    odin_dust({
+      initial(x) <- 1
+      update(x) <- 1
+      output(y) <- x * 2
+    }),
+    "Using unsupported features: 'has_output'")
+})


### PR DESCRIPTION
This was never actually added to odin.dust it seems, but dust never supported it. However, some vestiges had made it across in the prototype

Fixes #62