### PR TITLE
Create GPU code with scoped expressions to reduce register pressure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.8.9),
+    dust (>= 0.8.13),
     odin (>= 1.1.10),
     tibble,
     vctrs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.4
+Version: 0.2.5
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.8.13),
+    dust (>= 0.8.16),
     odin (>= 1.1.10),
     tibble,
     vctrs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.8.0),
+    dust (>= 0.8.9),
     odin (>= 1.1.10),
     tibble,
     vctrs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKAGE := $(shell grep '^Package:' DESCRIPTION | sed -E 's/^Package:[[:space:]]+//')
-RSCRIPT = Rscript --no-init-file
+RSCRIPT = Rscript
 
 all: install
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin.dust 0.2.5
+
+* More efficient GPU code generation (#75)
+
 # odin.dust 0.2.4
 
 * Support `as.numeric()` in odin code (since odin 1.1.10) (#43)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -630,19 +630,18 @@ generate_dust_gpu <- function(dat, rewrite) {
   ## after the parse phase.
   dat$gpu <- generate_dust_gpu_storage(dat)
 
-  c(generate_dust_gpu_declaration(dat),
-    generate_dust_gpu_size(dat, rewrite),
-    generate_dust_gpu_copy(dat, rewrite),
-    generate_dust_gpu_update(dat))
+  cpp_namespace("dust",
+                c(generate_dust_gpu_declaration(dat),
+                  generate_dust_gpu_size(dat, rewrite),
+                  generate_dust_gpu_copy(dat, rewrite),
+                  generate_dust_gpu_update(dat)))
 }
 
 
 generate_dust_gpu_declaration <- function(dat, rewrite) {
-  c("namespace dust {",
-    "template <>",
+  c("template <>",
     sprintf("struct has_gpu_support<%s> : std::true_type {};",
-            dat$config$base),
-    "}")
+            dat$config$base))
 }
 
 

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -899,7 +899,7 @@ dust_gpu_access <- function(x, info) {
       stopifnot(!is.null(d))
       sprintf("shared_int[%d]", d$offset)
     } else {
-      stopifnot(identical(x[[1]], as.name("+")))
+      stopifnot(as.character(x[[1]]) %in% c("+", "*"))
       sprintf("%s + %s", resolve_offset(x[[2]]), resolve_offset(x[[3]]))
     }
   }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -899,14 +899,14 @@ dust_gpu_storage_pack <- function(used, location, type, dat) {
   ## Split those back apart
   length <- offset[[length(names) + 1L]]
   offset <- set_names(offset[seq_along(names)], names)
-  type_dust <- if (type == "int") "int" else "real_t" # dust_type(type)
+  type_dust <- dust_type(type)
   ## TODO: this feels needlessly hard:
   location_dust <- sprintf("%s_%s", location,
                            if (type == "int") "int" else "real")
   if (location == "internal") {
-    type_array <- "dust::interleaved<real_t>"
+    type_array <- sprintf("dust::interleaved<%s>", type_dust)
   } else {
-    type_array <- "real_t *"
+    type_array <- sprintf("%s *", type_dust)
   }
 
   ## We don't do the final write here because we will need to

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -368,14 +368,12 @@ generate_dust_core_attributes <- function(dat) {
 }
 
 
-dust_unpack_variable <- function(name, dat, state, rewrite, gpu = FALSE) {
+dust_unpack_variable <- function(name, dat, state, rewrite) {
   x <- dat$data$variable$contents[[name]]
   data_info <- dat$data$elements[[name]]
   rhs <- dust_extract_variable(x, dat$data$elements, state, rewrite)
   if (data_info$rank == 0L) {
     fmt <- "const %s %s = %s;"
-  } else if (gpu) {
-    fmt <- "const dust::interleaved<%s> %s = %s;"
   } else {
     fmt <- "const %s * %s = %s;"
   }
@@ -923,17 +921,11 @@ dust_gpu_access <- function(x, info) {
   resolve_offset <- function(x) {
     if (is.numeric(x)) {
       as.character(x)
-    } else if (is.name(x) || is.character(x)) {
+    } else {
+      stopifnot(is.name(x) || is.character(x))
       d <- info[[as.character(x)]]
       stopifnot(!is.null(d))
       sprintf("shared_int[%d]", d$offset)
-    } else {
-      ## A test case to cover this would be anything with at least 3
-      ## internal arrays the same size, giving offsets
-      ## 0, n, 2 * n (vs 2 + n)
-      fn <- as.character(x[[1]])
-      stopifnot(fn %in% c("+", "*"))
-      sprintf("%s %s %s", resolve_offset(x[[2]]), fn, resolve_offset(x[[3]]))
     }
   }
 

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -899,8 +899,12 @@ dust_gpu_access <- function(x, info) {
       stopifnot(!is.null(d))
       sprintf("shared_int[%d]", d$offset)
     } else {
-      stopifnot(as.character(x[[1]]) %in% c("+", "*"))
-      sprintf("%s + %s", resolve_offset(x[[2]]), resolve_offset(x[[3]]))
+      ## A test case to cover this would be anything with at least 3
+      ## internal arrays the same size, giving offsets
+      ## 0, n, 2 * n (vs 2 + n)
+      fn <- as.character(x[[1]])
+      stopifnot(fn %in% c("+", "*"))
+      sprintf("%s %s %s", resolve_offset(x[[2]]), fn, resolve_offset(x[[3]]))
     }
   }
 

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -873,7 +873,7 @@ dust_gpu_storage_pack <- function(used, location, type, dat, extra = NULL) {
     if (!is_array[[i]]) {
       offset[[i + 1L]] <- i
     } else {
-      stopifnot(is.numeric(len[[i]]) || is.name(len[[i]]))
+      stopifnot(is.numeric(len[[i]]) || is.character(len[[i]]))
       len_i <- if (is.numeric(len[[i]])) len[[i]] else as.name(len[[i]])
       offset[[i + 1L]] <- call("+", offset[[i]], len_i)
     }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -16,9 +16,8 @@ generate_dust <- function(ir, options) {
 
   dat$meta$dust <- generate_dust_meta(options$real_t)
 
-  ## TODO: aim to remove this arg
-  rewrite <- function(x, gpu = FALSE) {
-    generate_dust_sexp(x, dat$data, dat$meta, dat$config$include$names, gpu)
+  rewrite <- function(x) {
+    generate_dust_sexp(x, dat$data, dat$meta, dat$config$include$names, FALSE)
   }
 
   dat$compare <- dust_compare_info(dat, rewrite)

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -680,11 +680,8 @@ generate_dust_gpu_update <- function(dat, rewrite) {
 
 generate_dust_gpu_size <- function(dat, rewrite) {
   dust_gpu_size <- function(x) {
-    ## TODO: This is all really ick and we'll refactor later.
-    name <- sprintf("dust::device_%s_size_%s<%s>",
-                    sub("_.+", "", x$location),
-                    if (x$type == "int") "int" else "real",
-                    dat$config$base)
+    name <- sprintf("dust::device_%s_size<%s>",
+                    x$location, dat$config$base)
     args <- set_names(dat$meta$dust$shared,
                       sprintf("dust::shared_ptr<%s>", dat$config$base))
     body <- sprintf("return %s;", rewrite(x$length))
@@ -692,8 +689,6 @@ generate_dust_gpu_size <- function(dat, rewrite) {
       cpp_function("size_t", name, args, body))
   }
 
-  ## TODO: it would be better if we renamed these in dust so that they
-  ## are device_size_<location>_<type>
   dust_flatten_eqs(lapply(dat$gpu$length, dust_gpu_size))
 }
 

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -173,7 +173,7 @@ generate_dust_core_initial <- function(dat, rewrite) {
     subs <- lapply(dat$data$variable$contents, function(x) rewrite(x$initial))
     eqs_initial <- dat$equations[dat$components$initial$equations]
     eqs_initial <- lapply(odin:::ir_substitute(eqs_initial, subs),
-                          generate_dust_equation, dat, rewrite)
+                          generate_dust_equation, dat, rewrite, FALSE)
   } else {
     eqs_initial <- NULL
   }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -662,13 +662,8 @@ generate_dust_gpu_update <- function(dat, rewrite) {
     "dust::interleaved<%s::real_t>" = dat$meta$result)
   names(args) <- sub("%s", dat$config$base, names(args), fixed = TRUE)
 
-  ## We will need to add in some additional bits for any new scalars
-  ## we want to store. For now don't worry though.
-  rewrite_gpu <- function(x) {
-    generate_dust_sexp(x, dat$data, dat$meta, dat$config$include$names, TRUE)
-  }
-  eqs <- generate_dust_equations(dat, rewrite_gpu,
-                                 dat$components$rhs$equations, TRUE)
+  eqs <- generate_dust_equations(dat, rewrite, dat$components$rhs$equations,
+                                 TRUE)
 
   body <- c(sprintf("typedef %s::real_t real_t;", dat$config$base),
             dust_flatten_eqs(eqs))

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -20,9 +20,11 @@ generate_dust_equation <- function(eq, dat, rewrite, gpu) {
   data_info <- dat$data$elements[[eq$lhs]]
   stopifnot(!is.null(data_info))
 
-  ## TODO: this requires refactoring to use some stateful rewriter
-  ## really. But we're still trying to find out if this approach is
-  ## faster so there's no point trying that yet.
+  ## NOTE: there's a little dance here to work out *exactly* what is
+  ## referenced in a GPU equation so that we can later on unpack
+  ## exactly those elements right before the equation. We can't rely
+  ## on "depends" etc because that is not specific enough about which
+  ## dimensions are referenced (for example).
   if (!is.null(dat$gpu)) {
     dat$data$gpu <- collector()
     rewrite <- function(x, gpu = FALSE) {

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -24,6 +24,11 @@ generate_dust_equation <- function(eq, dat, rewrite, gpu) {
 
   if (gpu) {
     req <- intersect(eq$depends$variables, names(dat$data$elements))
+    ## TODO: we might need to setdiff eq$name from access. This is
+    ## easy but no point doing it if it's never going to happen.
+    if (eq$name %in% req) {
+      stop("need a little rewrite here")
+    }
     access <- sprintf("const %s", dat$gpu$access[req])
 
     if (any(is.na(access))) {
@@ -36,8 +41,7 @@ generate_dust_equation <- function(eq, dat, rewrite, gpu) {
     }
 
     if (!identical(data_info$location, "variable")) {
-      message("Do we need to consider where we're writing to here?")
-      browser()
+      access <- c(access, dat$gpu$access[[eq$name]])
     }
 
     ret <- cpp_block(c(access, ret))

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -85,10 +85,9 @@ generate_dust_sexp <- function(x, data, meta, supported, gpu) {
     } else {
       x
     }
-  } else if (is.numeric(x)) {
-    deparse(x, control = "digits17")
   } else {
-    stop("Can't get here")
+    ## numeric here
+    deparse(x, control = "digits17")
   }
 }
 

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -2,6 +2,9 @@
 generate_dust_sexp <- function(x, data, meta, supported, gpu) {
   if (is.recursive(x)) {
     fn <- x[[1L]]
+    if (is.name(fn)) {
+      fn <- as.character(fn)
+    }
     args <- x[-1L]
     n <- length(args)
     values <- vcapply(args, generate_dust_sexp, data, meta, supported, gpu)
@@ -65,7 +68,10 @@ generate_dust_sexp <- function(x, data, meta, supported, gpu) {
       ret <- sprintf("%s(%s)", fn, paste(values, collapse = ", "))
     }
     ret
-  } else if (is.character(x)) {
+  } else if (is.character(x) || is.name(x)) {
+    if (is.name(x)) {
+      x <- as.character(x)
+    }
     el <- data$elements[[x]]
     if (!is.null(el$location) && el$location == "internal" && !gpu) {
       if (el$stage == "time") {
@@ -78,6 +84,8 @@ generate_dust_sexp <- function(x, data, meta, supported, gpu) {
     }
   } else if (is.numeric(x)) {
     deparse(x, control = "digits17")
+  } else {
+    stop("Can't get here")
   }
 }
 

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -72,6 +72,9 @@ generate_dust_sexp <- function(x, data, meta, supported, gpu) {
     if (is.name(x)) {
       x <- as.character(x)
     }
+    if (gpu) {
+      data$gpu$add(x)
+    }
     el <- data$elements[[x]]
     if (!is.null(el$location) && el$location == "internal" && !gpu) {
       if (el$stage == "time") {

--- a/R/generate_dust_sexp.R
+++ b/R/generate_dust_sexp.R
@@ -85,8 +85,7 @@ generate_dust_sexp <- function(x, data, meta, supported, gpu) {
     } else {
       x
     }
-  } else {
-    ## numeric here
+  } else if (is.numeric(x)) {
     deparse(x, control = "digits17")
   }
 }

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -134,9 +134,7 @@ odin_dust_code <- function(dat) {
     dat$gpu,
     dust_flatten_eqs(lapply(dat$support, "[[", "definition")),
     readLines(odin_dust_file("support.hpp")),
-    dat$create,
-    dat$info,
-    dat$data)
+    cpp_namespace("dust", c(dat$create, dat$info, dat$data)))
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,11 +41,6 @@ squote <- function(...) {
 }
 
 
-static_eval <- function(...) {
-  odin:::static_eval(...)
-}
-
-
 dust_array_access <- function(target, index, data, meta, supported, gpu) {
   mult <- data$elements[[target]]$dimnames$mult
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -41,6 +41,11 @@ squote <- function(...) {
 }
 
 
+static_eval <- function(...) {
+  odin:::static_eval(...)
+}
+
+
 dust_array_access <- function(target, index, data, meta, supported, gpu) {
   mult <- data$elements[[target]]$dimnames$mult
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -89,6 +89,11 @@ cpp_args <- function(return_type, name, args) {
 }
 
 
+cpp_block <- function(body) {
+  c("{", paste0("  ", body), "}")
+}
+
+
 odin_dust_file <- function(path) {
   system.file(path, package = "odin.dust", mustWork = TRUE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,6 +94,11 @@ cpp_block <- function(body) {
 }
 
 
+cpp_namespace <- function(name, code) {
+  c(sprintf("namespace %s {", name), code, "}")
+}
+
+
 odin_dust_file <- function(path) {
   system.file(path, package = "odin.dust", mustWork = TRUE)
 }

--- a/tests/testthat/test-sexp.R
+++ b/tests/testthat/test-sexp.R
@@ -3,11 +3,11 @@ context("sexp")
 test_that("Can use parens", {
   expr <- list("*", "a", list("+", "b", "c"))
   expect_equal(
-    generate_dust_sexp(expr, NULL, NULL, NULL),
+    generate_dust_sexp(expr, NULL, NULL, NULL, FALSE),
     "a * b + c")
   expr <- list("*", "a", list("(", list("+", "b", "c")))
   expect_equal(
-    generate_dust_sexp(expr, NULL, NULL, NULL),
+    generate_dust_sexp(expr, NULL, NULL, NULL, FALSE),
     "a * (b + c)")
 })
 
@@ -15,12 +15,12 @@ test_that("Can use parens", {
 test_that("^ becomes std::pow", {
   expr <- list("^", "a", "b")
   expect_equal(
-    generate_dust_sexp(expr, NULL, NULL, NULL),
+    generate_dust_sexp(expr, NULL, NULL, NULL, FALSE),
     "std::pow(a, b)")
 
   expr <- list("^", "a", list("+", "b", "c"))
   expect_equal(
-    generate_dust_sexp(expr, NULL, NULL, NULL),
+    generate_dust_sexp(expr, NULL, NULL, NULL, FALSE),
     "std::pow(a, b + c)")
 })
 
@@ -28,36 +28,36 @@ test_that("^ becomes std::pow", {
 test_that("if/else becomes ternary", {
   expr <- list("if", "cond", "a", "b")
   expect_equal(
-    generate_dust_sexp(expr, NULL, NULL, NULL),
+    generate_dust_sexp(expr, NULL, NULL, NULL, FALSE),
     "(cond ? a : b)")
 
   expr <- list("if", list(">", "x", "y"), list("+", "a", "x"),
                list("-", "b", "y"))
   expect_equal(
-    generate_dust_sexp(expr, NULL, NULL, NULL),
+    generate_dust_sexp(expr, NULL, NULL, NULL, FALSE),
     "(x > y ? a + x : b - y)")
 })
 
 
 test_that("Handling of log", {
   expect_equal(
-    generate_dust_sexp(list("log", "a"), NULL, NULL, NULL),
+    generate_dust_sexp(list("log", "a"), NULL, NULL, NULL, FALSE),
     "std::log(a)")
   expect_equal(
-    generate_dust_sexp(list("log", "a", "b"), NULL, NULL, NULL),
+    generate_dust_sexp(list("log", "a", "b"), NULL, NULL, NULL, FALSE),
     "(std::log(a) / std::log(b))")
   expect_equal(
-    generate_dust_sexp(list("log10", "a"), NULL, NULL, NULL),
+    generate_dust_sexp(list("log10", "a"), NULL, NULL, NULL, FALSE),
     "std::log10(a)")
 })
 
 
 test_that("2-arg round is not supported", {
   expect_equal(
-    generate_dust_sexp(list("round", "a"), NULL, NULL, NULL),
+    generate_dust_sexp(list("round", "a"), NULL, NULL, NULL, FALSE),
     "std::round(a)")
   expect_error(
-    generate_dust_sexp(list("round", "a", "b"), NULL, NULL, NULL),
+    generate_dust_sexp(list("round", "a", "b"), NULL, NULL, NULL, FALSE),
     "odin.dust does not support 2-arg round",
     fixed = TRUE)
 })
@@ -74,21 +74,23 @@ test_that("fold min/max", {
     generate_dust_sexp(list("min", "a", "b", "c"), NULL, NULL, NULL, FALSE),
     "std::min(a, std::min(b, c))")
 
+  dat <- list(gpu = collector())
   expect_equal(
-    generate_dust_sexp(list("min", "a"), NULL, NULL, NULL, TRUE),
+    generate_dust_sexp(list("min", "a"), dat, NULL, NULL, TRUE),
     "a")
   expect_equal(
-    generate_dust_sexp(list("min", "a", "b"), NULL, NULL, NULL, TRUE),
+    generate_dust_sexp(list("min", "a", "b"), dat, NULL, NULL, TRUE),
     "odin_min(a, b)")
   expect_equal(
-    generate_dust_sexp(list("min", "a", "b", "c"), NULL, NULL, NULL, TRUE),
+    generate_dust_sexp(list("min", "a", "b", "c"), dat, NULL, NULL, TRUE),
     "odin_min(a, odin_min(b, c))")
+  expect_setequal(dat$gpu$get(), c("a", "b", "c"))
 
   expect_equal(
     generate_dust_sexp(list("max", "a", "b", "c"), NULL, NULL, NULL, FALSE),
     "std::max(a, std::max(b, c))")
   expect_equal(
-    generate_dust_sexp(list("max", "a", "b", "c"), NULL, NULL, NULL, TRUE),
+    generate_dust_sexp(list("max", "a", "b", "c"), dat, NULL, NULL, TRUE),
     "odin_max(a, odin_max(b, c))")
 })
 
@@ -96,20 +98,20 @@ test_that("fold min/max", {
 test_that("generate random number code", {
   meta <- list(dust = list(rng_state = "rng_state"))
   expect_equal(
-    generate_dust_sexp(list("rbinom", "n", "p"), NULL, meta, NULL),
+    generate_dust_sexp(list("rbinom", "n", "p"), NULL, meta, NULL, FALSE),
     "dust::distr::rbinom(rng_state, std::round(n), p)")
   expect_equal(
-    generate_dust_sexp(list("rpois", "lambda"), NULL, meta, NULL),
+    generate_dust_sexp(list("rpois", "lambda"), NULL, meta, NULL, FALSE),
     "dust::distr::rpois(rng_state, lambda)")
   expect_equal(
-    generate_dust_sexp(list("runif", "a", "b"), NULL, meta, NULL),
+    generate_dust_sexp(list("runif", "a", "b"), NULL, meta, NULL, FALSE),
     "dust::distr::runif(rng_state, a, b)")
   expect_equal(
-    generate_dust_sexp(list("rnorm", "mu", "sd"), NULL, meta, NULL),
+    generate_dust_sexp(list("rnorm", "mu", "sd"), NULL, meta, NULL, FALSE),
     "dust::distr::rnorm(rng_state, mu, sd)")
 
   expect_error(
-    generate_dust_sexp(list("rchisq", "df"), NULL, meta, NULL),
+    generate_dust_sexp(list("rchisq", "df"), NULL, meta, NULL, FALSE),
     "unsupported function 'rchisq'")
 })
 
@@ -134,13 +136,15 @@ test_that("Generate sum code", {
                                           mult = c("", "dim_m_1"))),
                                dim_m = scalar_int("dim_m"),
                                dim_m_1 = scalar_int("dim_m_1"),
-                               dim_m_2 = scalar_int("dim_m_2")))
+                               dim_m_2 = scalar_int("dim_m_2")),
+               gpu = collector())
   expect_equal(
     generate_dust_sexp(list("sum", "m"), data, meta, NULL, FALSE),
     "odin_sum1<real_t>(internal.m.data(), 0, shared->dim_m)")
   expect_equal(
     generate_dust_sexp(list("sum", "m"), data, meta, NULL, TRUE),
     "odin_sum1<real_t>(m, 0, dim_m)")
+  expect_setequal(data$gpu$get(), c("m", "dim_m"))
 
   expr <- list("sum", "m",
                1L, list("dim", "m", 1),
@@ -163,21 +167,21 @@ test_that("Generate sum code", {
 
 test_that("renames", {
   expect_equal(
-    generate_dust_sexp(list("gamma", "x"), NULL, NULL, NULL),
+    generate_dust_sexp(list("gamma", "x"), NULL, NULL, NULL, FALSE),
     "std::tgamma(x)")
   expect_equal(
-    generate_dust_sexp(list("lgamma", "x"), NULL, NULL, NULL),
+    generate_dust_sexp(list("lgamma", "x"), NULL, NULL, NULL, FALSE),
     "std::lgamma(x)")
   expect_equal(
-    generate_dust_sexp(list("ceiling", "x"), NULL, NULL, NULL),
+    generate_dust_sexp(list("ceiling", "x"), NULL, NULL, NULL, FALSE),
     "std::ceil(x)")
   expect_equal(
-    generate_dust_sexp(list("as.integer", "x"), NULL, NULL, NULL),
+    generate_dust_sexp(list("as.integer", "x"), NULL, NULL, NULL, FALSE),
     "static_cast<int>(x)")
   expect_equal(
-    generate_dust_sexp(list("as.numeric", "x"), NULL, NULL, NULL),
+    generate_dust_sexp(list("as.numeric", "x"), NULL, NULL, NULL, FALSE),
     "static_cast<real_t>(x)")
   expect_equal(
-    generate_dust_sexp(list("%%", "x", "y"), NULL, NULL, NULL),
+    generate_dust_sexp(list("%%", "x", "y"), NULL, NULL, NULL, FALSE),
     "fmodr<real_t>(x, y)")
 })


### PR DESCRIPTION
This PR totally rewrites the gpu code so that rather than generating code like the CPU version where we unpack everything then run each equation in turn, we unpack locally to each expression. The hope here is that reduces the register pressure (and indeed with sircovid it does)

Fixes #75 