### PR TITLE
Update to work with dust 0.9.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.5
+Version: 0.2.6
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.8.16),
+    dust (>= 0.9.0),
     odin (>= 1.1.10),
     tibble,
     vctrs
@@ -36,5 +36,5 @@ Suggests:
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust,
+    mrc-ide/dust@cuda-filter,
     mrc-ide/odin

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,5 +36,5 @@ Suggests:
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust@cuda-filter,
+    mrc-ide/dust,
     mrc-ide/odin

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -123,7 +123,7 @@ generate_dust_core_struct <- function(dat) {
     data_t <- "typedef dust::no_data data_t;"
   } else {
     data_t <- c(
-      "struct data_t {",
+      "struct ALIGN(16) data_t {",
       sprintf("  %s %s;", unname(dat$compare$data), names(dat$compare$data)),
       "};")
   }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -699,10 +699,7 @@ generate_dust_gpu_compare <- function(dat) {
   names(args) <- sub("%s", base, names(args), fixed = TRUE)
 
   body <- collector()
-  ## We don't actually want this all the time as it will conflict!
-  if (!any(grepl("typedef\\s+typename\\s+.+::real_t real_t", code))) {
-    body$add("typedef %s::real_t real_t;", base)
-  }
+  body$add("typedef %s::real_t real_t;", base)
   body$add(dat$gpu$access[dat$compare$used])
   body$add(transform_compare_odin_gpu(code))
 
@@ -980,6 +977,8 @@ transform_compare_odin_gpu <- function(code) {
   drop <- c(seq_len(grep("{", code, fixed = TRUE)[[1]]),
             seq(max(grep("}", code, fixed = TRUE)), length(code)))
   code <- code[-drop]
+
+  code <- code[!grepl("typedef\\s+typename\\s+T::real_t\\s+real_t", code)]
 
   ## As a sanity check here, we'll look at the indenting and make sure
   ## that everything is at least as indented as the first line:

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -647,6 +647,7 @@ generate_dust_gpu <- function(dat, rewrite) {
 
 generate_dust_gpu_declaration <- function(dat, rewrite) {
   c("template <>",
+    "DEVICE",
     sprintf("struct has_gpu_support<%s> : std::true_type {};",
             dat$config$base))
 }

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -457,6 +457,7 @@ read_compare_dust <- function(filename) {
   data <- vcapply(data, as.character)
 
   list(function_name = function_name,
+       function_defn = ctx,
        data = data)
 }
 
@@ -505,10 +506,9 @@ dust_compare_info <- function(dat, rewrite) {
   }
   filename <- dat$config$custom[[which(i)]]$value
   ret <- read_compare_dust(filename)
-  ret$source <- readLines(filename)
   ret$filename <- filename
 
-  res <- dust_compare_rewrite(ret$source, dat, rewrite, filename)
+  res <- dust_compare_rewrite(readLines(filename), dat, rewrite, filename)
 
   ret$used <- res$used
   ret$include <- res$result
@@ -682,7 +682,7 @@ generate_dust_gpu_compare <- function(dat) {
     return(NULL)
   }
 
-  code <- dat$compare$source
+  code <- dat$compare$function_defn
 
   base <- dat$config$base
   return_type <- sprintf("DEVICE %s::real_t", base)

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -119,14 +119,15 @@ test_that("rewrite compare source", {
 
   expect_equal(
     dust_compare_rewrite(c("a", "a + odin(a)", "y / odin(b)"), dat, rewrite,
-                         filename),
+                         filename)$result,
     c("a", "a + shared->a", "y / internal.b"))
   expect_equal(
-    dust_compare_rewrite(c("a", "odin(x) + odin(a)"), dat, rewrite, filename),
+    dust_compare_rewrite(c("a", "odin(x) + odin(a)"), dat, rewrite,
+                         filename)$result,
     c("a", "state[4] + shared->a"))
   expect_equal(
     dust_compare_rewrite(c("a", "odin( x ) + odin( a )"), dat, rewrite,
-                         filename),
+                         filename)$result,
     c("a", "state[4] + shared->a"))
   expect_error(
     dust_compare_rewrite(c("a", "odin(y) + odin(a)"), dat, rewrite, filename),
@@ -234,4 +235,12 @@ test_that("Sensible error message when files are not found in other dir", {
     odin_dust(filename),
     "Did not find a file 'examples/compare_simple.cpp' (relative to odin",
     fixed = TRUE)
+})
+
+
+test_that("rewrite compare for gpu", {
+  dat <- read_compare_dust("examples/compare.cpp")
+  res <- transform_compare_odin_gpu(dat$function_defn)
+  expect_false(any(grepl("typedef.+real_t", res)))
+  expect_false(any(grepl("odin\\(", res)))
 })

--- a/tests/testthat/test-compare.R
+++ b/tests/testthat/test-compare.R
@@ -244,3 +244,12 @@ test_that("rewrite compare for gpu", {
   expect_false(any(grepl("typedef.+real_t", res)))
   expect_false(any(grepl("odin\\(", res)))
 })
+
+
+test_that("rewrite compare for gpu complains if indenting is bad", {
+  dat <- read_compare_dust("examples/compare.cpp")
+  code <- sub("\\s+return", "return", dat$function_defn)
+  expect_error(
+    transform_compare_odin_gpu(code),
+    "Detected inconsistent indenting while reformatting compare function")
+})


### PR DESCRIPTION
Support for device compiled compare functions

This needs merging in concert with https://github.com/mrc-ide/sircovid/pull/297 and https://github.com/mrc-ide/dust/pull/224

