### PR TITLE
Allow two shared integer vectors

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,6 +69,12 @@ jobs:
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 
+      - name: Force install oai/socialmixr
+        if: runner.os == 'Linux'
+        run: |
+          install.packages(c("oai", "socialmixr"), type = "source")
+        shell: Rscript {0}
+
       - name: Force install XML
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -72,7 +72,10 @@ jobs:
       - name: Force install oai/socialmixr
         if: runner.os == 'Linux'
         run: |
-          install.packages(c("oai", "socialmixr"), type = "source")
+          if (!requireNamespace("socialmixr", quietly = TRUE)) {
+            remotes::install_github("cran/oai", upgrade = FALSE)
+            install.packages("socialmixr")
+          }
         shell: Rscript {0}
 
       - name: Force install XML

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.6
+Version: 0.2.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),


### PR DESCRIPTION
This fixes a bug seen by @RaphaelS1 in https://github.com/mrc-ide/sircovid/pull/306 where code generation failed if two (or more) shared integer vectors were present, because offset generation failed. A little fiddly but the original solution was very close