### PR TITLE
Minor updates to work with new dust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.7
+Version: 0.2.8
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.9.0),
+    dust (>= 0.9.10),
     odin (>= 1.1.10),
     tibble,
     vctrs

--- a/tests/testthat/test-gpu.R
+++ b/tests/testthat/test-gpu.R
@@ -13,7 +13,7 @@ test_that("Can generate interleaved interface for basic model", {
   }, options = odin_dust_options(gpu_generate = TRUE))
 
   mod1 <- gen$new(list(len = 10), 0, 10, seed = 1L)
-  mod2 <- gen$new(list(len = 10), 0, 10, seed = 1L, device_id = 0L)
+  mod2 <- gen$new(list(len = 10), 0, 10, seed = 1L, device_config = 0L)
   expect_identical(
     mod1$run(10),
     mod2$run(10, device = TRUE))
@@ -35,7 +35,7 @@ test_that("Can generate gpu code with internal storage", {
   }, options = odin_dust_options(gpu_generate = TRUE))
 
   mod1 <- gen$new(list(len = 10), 0, 10, seed = 1L)
-  mod2 <- gen$new(list(len = 10), 0, 10, seed = 1L, device_id = 0L)
+  mod2 <- gen$new(list(len = 10), 0, 10, seed = 1L, device_config = 0L)
   expect_identical(
     mod1$run(10),
     mod2$run(10, device = TRUE))
@@ -82,7 +82,7 @@ test_that("Can run basic sums on device", {
   nc <- 7
   m <- matrix(runif(nr * nc), nr, nc)
   mod1 <- gen$new(list(m_user = m), 0, 1)
-  mod2 <- gen$new(list(m_user = m), 0, 1, device_id = 0L)
+  mod2 <- gen$new(list(m_user = m), 0, 1, device_config = 0L)
 
   y1 <- mod1$transform_variables(drop(mod1$run(1)))
   y2 <- mod1$transform_variables(drop(mod2$run(1, device = TRUE)))
@@ -104,7 +104,7 @@ test_that("Generate correct code with scalars and vectors in shared", {
 
   p <- list(a = runif(1), b = runif(1), x = runif(10), y = runif(5))
   mod1 <- gen$new(p, 0, 1, seed = 1L)
-  mod2 <- gen$new(p, 0, 1, seed = 1L, device_id = 0L)
+  mod2 <- gen$new(p, 0, 1, seed = 1L, device_config = 0L)
   expect_identical(mod1$run(5),
                    mod2$run(5, device = TRUE))
 })
@@ -125,7 +125,7 @@ test_that("Use offsets correctly", {
   }, options = odin_dust_options(gpu_generate = TRUE))
 
   mod1 <- gen$new(list(), 0, 13, seed = 1L)
-  mod2 <- gen$new(list(), 0, 13, seed = 1L, device_id = 0L)
+  mod2 <- gen$new(list(), 0, 13, seed = 1L, device_config = 0L)
   expect_identical(mod1$run(5),
                    mod2$run(5, device = TRUE))
 })
@@ -140,7 +140,7 @@ test_that("gpu and gpu-free versions do not interfere in cache", {
     gen1$new(list(I_ini = 1), 0, 1)$run(0, device = TRUE),
     "GPU support not enabled for this object")
   expect_silent(
-    gen2$new(list(I_ini = 1), 0, 1, device_id = 0L)$run(0, device = TRUE))
+    gen2$new(list(I_ini = 1), 0, 1, device_config = 0L)$run(0, device = TRUE))
 })
 
 
@@ -203,7 +203,7 @@ test_that("Can create compare function with gpu code", {
 
   p <- list()
   mod1 <- gen$new(p, 0, 1, seed = 1L)
-  mod2 <- gen$new(p, 0, 1, seed = 1L, device_id = 0L)
+  mod2 <- gen$new(p, 0, 1, seed = 1L, device_config = 0L)
 
   t <- seq(0, 20, by = 2)
   d <- dust::dust_data(
@@ -252,7 +252,7 @@ test_that("Can include a pair of integer vectors in gpu shared memory", {
                index_z1 = sample(10),
                index_z2 = sample(10))
   mod_cpu <- gen$new(pars, 0, 1)
-  mod_gpu <- gen$new(pars, 0, 1, device_id = 0L)
+  mod_gpu <- gen$new(pars, 0, 1, device_config = 0L)
 
   y_cpu <- mod_cpu$run(1, device = FALSE)
   y_gpu <- mod_gpu$run(1, device = TRUE)


### PR DESCRIPTION
Affects only the tests, which replace device_id with device_config
Can be merged after https://github.com/mrc-ide/dust/pull/246, all
generated code is still ok