### PR TITLE
Avoid stack overflow when generating large sums

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.14
+Version: 0.2.15
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# odin.dust 0.2.15
+
+* Avoid stack overflow when generating very long expressions
+
 # odin.dust 0.2.5
 
 * More efficient GPU code generation (#75)


### PR DESCRIPTION
This PR fixes a stack overflow seen by Ed when generating gpu code for sircovid as this includes a very large sum (hundreds of terms). That causes odin's recursive rewrite to fail. Here, we unfold the tree `(+ (+ (+ a b) c) d)` to `(+ a b c d)` which prevents this