### PR TITLE
Use correct NA value for user handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.15
+Version: 0.2.16
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -92,8 +92,9 @@ generate_dust_equation_user <- function(eq, data_info, dat, rewrite, gpu) {
   lhs <- rewrite(eq$lhs)
   storage_type <- dust_type(data_info$storage_type)
   is_integer <- if (storage_type == "int") "true" else "false"
-  min <- rewrite(eq$user$min %||% "NA_REAL")
-  max <- rewrite(eq$user$max %||% "NA_REAL")
+  na_value <- if (is_integer) "NA_INTEGER" else "NA_REAL"
+  min <- rewrite(eq$user$min %||% na_value)
+  max <- rewrite(eq$user$max %||% na_value)
   previous <- lhs
 
   if (eq$user$dim) {

--- a/tests/testthat/helper-odin-dust.R
+++ b/tests/testthat/helper-odin-dust.R
@@ -24,3 +24,14 @@ user_wrapper <- function() {
 sub_package_name <- function(text, name) {
   gsub("{{name}}", name, text, fixed = TRUE)
 }
+
+
+## Quick fix for
+## https://github.com/mrc-ide/odin.dust/issues/85
+## Will think about this and implement as an API function later.
+odin_dust_generate <- function(code) {
+  ir <- odin::odin_parse_(code)
+  options <- odin_dust_options()
+  dat <- generate_dust(ir, options)
+  odin_dust_code(dat)
+}

--- a/tests/testthat/test-user.R
+++ b/tests/testthat/test-user.R
@@ -181,3 +181,24 @@ test_that("Correct if data exists and is provided", {
                                   NA_real_, NA_real_),
     list(v2, dim(a2)))
 })
+
+
+test_that("Generate correct types for user variables", {
+  ## We were previously including NA_REAL as the default which is not
+  ## the same as NA_INTEGER and causing weird errors on M1 (ARM) macs
+  ## only.
+
+  code <- odin_dust_generate(quote({
+    var_a <- user(integer = TRUE)
+    var_b <- user(integer = FALSE)
+    initial(x) <- 1
+    update(x) <- x + var_a + var_b
+  }))
+
+  expect_match(
+    grep("user_get_scalar.+var_a", code, value = TRUE),
+    "NA_INTEGER, NA_INTEGER\\);$")
+  expect_match(
+    grep("user_get_scalar.+var_b", code, value = TRUE),
+    "NA_REAL, NA_REAL\\);$")
+})


### PR DESCRIPTION
As found by @annecori, we wrote code that performed poorly on an ARM Mac.

The testing is not ideal, but should at least prevent regressions. There's no obvious way of triggering this without running on an M1 which is not really possible in a CI environment.  Fix confirmed on Anne's machine.