### PR TITLE
Fix for compilation of vector-using mixed models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.17
+Version: 0.2.18
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("John", "Lees", role = "aut"),

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -123,14 +123,14 @@ odin_dust_wrapper <- function(ir, srcdir, options) {
   path <- tempfile(fileext = ".cpp")
   writeLines(code, path)
 
-  if (dat$discrete) {
-    generator <- dust::dust(path, quiet = !options$verbose,
-                            workdir = options$workdir,
-                            gpu = options$gpu$compile)
-  } else {
+  if (dat$continuous) {
     generator <- mode::mode(path,
                             quiet = !options$verbose,
                             workdir = options$workdir)
+  } else {
+    generator <- dust::dust(path, quiet = !options$verbose,
+                            workdir = options$workdir,
+                            gpu = options$gpu$compile)
   }
   if (!("transform_variables" %in% names(generator$public_methods))) {
     generator$set("public", "transform_variables",

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -574,3 +574,33 @@ test_that("Can compile mixed deterministic/stochastic model", {
   expect_equal(t(apply(cbind(0, out[1, , ]), 1, diff)),
                out[2, , ])
 })
+
+
+test_that("Can compile a mixed model that includes a vector variable", {
+  gen <- odin_dust({
+    initial(x) <- 0
+    deriv(x) <- a
+    initial(y[]) <- 0
+    deriv(y[]) <- a
+    dim(y) <- 5
+    initial(a) <- 0
+    update(a) <- a + rnorm(0, 1)
+  }, verbose = TRUE)
+
+  mod <- gen$new(list(), 0, 10, seed = 1)
+  info <- mod$info()
+  mod$set_stochastic_schedule(0:3)
+  y <- array(NA_real_, c(7, 10, 4))
+  for (i in seq_len(4)) {
+    y[, , i] <- mod$run(i)
+  }
+
+  cmp <- dust::dust_rng$new(seed = 1, n_streams = 10)$normal(4, 0, 1)
+  expect_equal(t(apply(cmp, 2, cumsum)), y[info$index$a, , ],
+               tolerance = 1e-15)
+  expect_equal(t(apply(cbind(0, y[info$index$x, , ]), 1, diff)),
+               y[info$index$a, , ])
+  expect_equal(
+    y[info$index$y, , ],
+    y[rep(info$index$x, 5), , ])
+})


### PR DESCRIPTION
Issue was because we were testing against `discrete` (model contains discrete steps) not against `continuous` (model will use continuous time - and therefore use mode). Tidied up the other places this might have bitten too.

The test is pretty rubbish but does generate a model of the same type as the issue that you hit