### PR TITLE
Allow pulling in additional C++ dependencies

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          pak-version: devel
           extra-packages: any::rcmdcheck
           needs: check
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,6 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          pak-version: devel
           extra-packages: any::pkgdown, local::.
           needs: website
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          pak-version: devel
           extra-packages: any::covr
           needs: coverage
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.12.4),
+    dust (>= 0.12.5),
     mode (>= 0.1.6),
     odin (>= 1.3.5),
     tibble,
@@ -38,6 +38,6 @@ RoxygenNote: 7.2.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust@mrc-3830,
+    mrc-ide/dust,
     mrc-ide/mode,
     mrc-ide/odin

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.27
+Version: 0.2.28
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),
@@ -34,7 +34,7 @@ Suggests:
     rmarkdown,
     socialmixr,
     testthat
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.12.0),
+    dust (>= 0.12.4),
     mode (>= 0.1.6),
     odin (>= 1.3.5),
     tibble,
@@ -38,6 +38,6 @@ RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust,
+    mrc-ide/dust@mrc-3830,
     mrc-ide/mode,
     mrc-ide/odin

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -317,7 +317,7 @@ generate_dust_core_create <- function(eqs, dat, rewrite) {
     ## compiler which warns us. If we find all the likely culprits and
     ## zero them we get rid of the warning.
     pos <- names_if(vlapply(dat$data$elements, function(x) {
-      x$location == "internal" && x$rank == 0
+      x$location == "internal" && x$rank == 0 && x$stage == "time"
     }))
     for (nm in setdiff(pos, dat$components$create$equations)) {
       body$add(sprintf("%s.%s = 0;", dat$meta$internal, nm))

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -854,7 +854,7 @@ generate_dust_gpu_size <- function(dat, rewrite) {
 
 
 generate_dust_gpu_copy <- function(dat, rewrite) {
-  name <- sprintf("dust::gpu::shared_copy<%s>", dat$config$base)
+  name <- sprintf("shared_copy<%s>", dat$config$base)
   args <- c(
     "dust::shared_ptr<%s>" = dat$meta$dust$shared,
     "int *" = dat$meta$dust$shared_int,

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -193,7 +193,7 @@ read_include_dust <- function(filename) {
 
 
 odin_dust_linking_to <- function(code) {
-  if (is.null(code) || !grepl("linking_to", code)) {
+  if (is.null(code) || !any(grepl("linking_to", code))) {
     return(NULL)
   }
   tmp <- tempfile()

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -235,9 +235,7 @@ odin_dust_cpp_std <- function(decorations) {
       stop("Expected exactly one argument to odin.dust::cpp_std")
     }
     x <- x[[1L]]
-    if (is.name(x)) {
-      x <- as.character(x)
-    } else if (is.recursive(x)) {
+    if (is.language(x)) {
       x <- gsub(" ", "", deparse(x))
     }
     x

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -5,6 +5,20 @@
 ##' many uses this should be considerably faster than the interface
 ##' that odin normally uses (built on dde).
 ##'
+##' @section Including custom code:
+##'
+##' When including custom C++ code you may want to set additional
+##'   options in order to enable compilation. You can do this by
+##'   including pseudo-attributes
+##'
+##' * `// [[odin.dust::cpp_std(C++17)]]` - use this to change the C++
+##'   standard used in compilation; this is passed to [dust::dust()]
+##'   as the `cpp_std` option. It is only necessary to pass in values
+##'   greater than C++11 at present as that is dust's default.
+##' * `// [[odin.dust::linking_to(pkg)]]` - use this to make include
+##'   files present in an R package (e.g., BH) available. You can use
+##'   as many of these attributes as you need.
+##'
 ##' @title Create a dust odin model
 ##'
 ##' @param x Either the name of a file to read, a text string (if

--- a/man/odin_dust.Rd
+++ b/man/odin_dust.Rd
@@ -34,3 +34,20 @@ instead creating the more limited dust interface. However, for
 many uses this should be considerably faster than the interface
 that odin normally uses (built on dde).
 }
+\section{Including custom code}{
+
+
+When including custom C++ code you may want to set additional
+options in order to enable compilation. You can do this by
+including pseudo-attributes
+\itemize{
+\item \verb{// [[odin.dust::cpp_std(C++17)]]} - use this to change the C++
+standard used in compilation; this is passed to \code{\link[dust:dust]{dust::dust()}}
+as the \code{cpp_std} option. It is only necessary to pass in values
+greater than C++11 at present as that is dust's default.
+\item \verb{// [[odin.dust::linking_to(pkg)]]} - use this to make include
+files present in an R package (e.g., BH) available. You can use
+as many of these attributes as you need.
+}
+}
+

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -774,7 +774,7 @@ test_that("can extract cpp_std requirements", {
     "C++14")
   expect_equal(
     odin_dust_cpp_std(include_decorations(
-      '// [[odin.dust::cpp_std(lovely)]]\ncode\n')),
+      "// [[odin.dust::cpp_std(lovely)]]\ncode\n")),
     "lovely")
 
   expect_error(

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -717,19 +717,22 @@ test_that("include initialisation of time-varying variables", {
 
 
 test_that("can extract linking_to requirements", {
-  expect_null(odin_dust_linking_to(NULL))
-  expect_null(odin_dust_linking_to("code"))
+  expect_null(odin_dust_linking_to(include_decorations(NULL)))
+  expect_null(odin_dust_linking_to(include_decorations("code")))
 
   expect_equal(
-    odin_dust_linking_to("// [[odin.dust::linking_to(pkg1)]]\ncode\n"),
+    odin_dust_linking_to(include_decorations(
+      "// [[odin.dust::linking_to(pkg1)]]\ncode\n")),
     "pkg1")
   expect_equal(
-    odin_dust_linking_to("// [[odin.dust::linking_to(pkg1, pkg2)]]\ncode\n"),
+    odin_dust_linking_to(include_decorations(
+      "// [[odin.dust::linking_to(pkg1, pkg2)]]\ncode\n")),
     c("pkg1", "pkg2"))
   expect_equal(
-    odin_dust_linking_to(paste("// [[odin.dust::linking_to(pkg1, pkg2)]]",
-                               "// [[odin.dust::linking_to(pkg3)]]",
-                               "code", sep = "\n")),
+    odin_dust_linking_to(include_decorations(
+      paste("// [[odin.dust::linking_to(pkg1, pkg2)]]",
+            "// [[odin.dust::linking_to(pkg3)]]",
+            "code", sep = "\n"))),
     c("pkg1", "pkg2", "pkg3"))
 })
 
@@ -754,4 +757,66 @@ test_that("generate code with additional packages", {
   expect_setequal(
     strsplit(desc[["LinkingTo"]], ", ")[[1]],
     c("cpp11", "dust"))
+})
+
+
+test_that("can extract cpp_std requirements", {
+  expect_null(odin_dust_cpp_std(include_decorations(NULL)))
+  expect_null(odin_dust_cpp_std(include_decorations("code")))
+
+  expect_equal(
+    odin_dust_cpp_std(include_decorations(
+      '// [[odin.dust::cpp_std("C++14")]]\ncode\n')),
+    "C++14")
+  expect_equal(
+    odin_dust_cpp_std(include_decorations(
+      "// [[odin.dust::cpp_std(C++14)]]\ncode\n")),
+    "C++14")
+
+  expect_error(
+    odin_dust_cpp_std(include_decorations(
+      "// [[odin.dust::cpp_std()]]\ncode\n")),
+    "Expected exactly one argument to odin.dust::cpp_std")
+  expect_error(
+    odin_dust_cpp_std(include_decorations(
+      "// [[odin.dust::cpp_std(C++11, C++14)]]\ncode\n")),
+    "Expected exactly one argument to odin.dust::cpp_std")
+
+  code <- paste(
+    "// [[odin.dust::cpp_std(C++14)]]",
+    "// [[odin.dust::cpp_std(C++17)]]",
+    "code", sep = "\n")
+  expect_message(
+    res <- odin_dust_cpp_std(include_decorations(code)),
+    "More than one 'odin.dust::cpp11_std', using 'C++17'",
+    fixed = TRUE)
+  expect_equal(res, "C++17")
+
+  code <- paste(
+    "// [[odin.dust::cpp_std(C++17)]]",
+    "// [[odin.dust::cpp_std(C++17)]]",
+    "code", sep = "\n")
+  expect_silent(res <- odin_dust_cpp_std(include_decorations(code)))
+  expect_equal(res, "C++17")
+})
+
+
+test_that("generate code that uses different c++ version", {
+  tmp <- tempfile()
+  dir.create(tmp)
+  writeLines(c("// [[odin.dust::cpp_std(C++17)]]", readLines("include.cpp")),
+             file.path(tmp, "include.cpp"))
+  gen <- with_dir(
+    tmp,
+    odin_dust({
+      config(include) <- "include.cpp"
+      n <- 5
+      x[] <- user()
+      initial(y[]) <- 0
+      update(y[]) <- cumulative_to_i(i, x)
+      dim(x) <- n
+      dim(y) <- n
+    }, workdir = "pkg"))
+  desc <- as.list(read.dcf(file.path(tmp, "pkg", "DESCRIPTION"))[1, ])
+  expect_equal(desc[["SystemRequirements"]], "C++17")
 })

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -772,6 +772,10 @@ test_that("can extract cpp_std requirements", {
     odin_dust_cpp_std(include_decorations(
       "// [[odin.dust::cpp_std(C++14)]]\ncode\n")),
     "C++14")
+  expect_equal(
+    odin_dust_cpp_std(include_decorations(
+      '// [[odin.dust::cpp_std(lovely)]]\ncode\n')),
+    "lovely")
 
   expect_error(
     odin_dust_cpp_std(include_decorations(


### PR DESCRIPTION
This PR uses additional comments/attributes to control the C++ standard and additional packages used by dust (see https://github.com/mrc-ide/dust/pull/380 and https://github.com/mrc-ide/dust/pull/381).

~Contains commits from #120; until that is megrged, see https://github.com/mrc-ide/odin.dust/compare/mrc-3832...mrc-3829 for the diff~