### PR TITLE
Avoid compiler warnings with initial time varying

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.26
+Version: 0.2.27
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,6 @@ Description: Less painful than it sounds, this package compiles an
     no interpolation and no delays).
 License: MIT + file LICENSE
 Encoding: UTF-8
-LazyData: true
 Language: en-GB
 URL: https://github.com/mrc-ide/odin.dust
 BugReports: https://github.com/mrc-ide/odin.dust/issues

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -329,6 +329,10 @@ generate_dust_core_create <- function(eqs, dat, rewrite) {
   body$add("return %s(%s, %s);",
            pars_type, dat$meta$dust$shared, dat$meta$internal)
 
+  ## Only add the 'real_type' type declaration if it looks likely we
+  ## use it, avoiding a compiler warning. This is actually fairly hard
+  ## to reason about so just use a heuristic as false positives are
+  ## harmless except the warning.
   body_txt <- body$get()
   if (any(grepl("real_type", body_txt, fixed = TRUE))) {
     body_txt <- c(
@@ -373,22 +377,9 @@ generate_dust_core_info <- function(dat, rewrite) {
   body$add('         "len"_nm = len,')
   body$add('         "index"_nm = index});')
 
-  ## Only add the 'internal' assignment if it looks likely we use it,
-  ## avoiding a compiler warning. This is actually fairly hard to
-  ## reason about so just use a heuristic as false positives are
-  ## harmless except the warning.
-  body_txt <- body$get()
-  if (any(grepl("internal.", body_txt, fixed = TRUE))) {
-    body_txt <- c(
-      sprintf("const %s::internal_type %s = %s.%s;",
-              dat$config$base, dat$meta$internal, dat$meta$dust$pars,
-              dat$meta$internal),
-      body_txt)
-  }
-
   name <- sprintf("%s_info<%s>", dat$meta$namespace, dat$config$base)
   c("template <>",
-    cpp_function("cpp11::sexp", name, args, body_txt))
+    cpp_function("cpp11::sexp", name, args, body$get()))
 }
 
 

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -703,3 +703,14 @@ test_that("compile model with rgamma", {
   cmp <- dust::dust_rng$new(1, seed = 1L)$gamma(100, 3, 2.6)
   expect_equal(y, cmp)
 })
+
+
+test_that("include initialisation of time-varying variables", {
+  ## A nice test here would check for compiler warnings, but that's
+  ## basically impossible to write portably.
+  tmp <- tempfile()
+  gen <- odin_dust(c("initial(time) <- step + 1", "update(time) <- step + 1"),
+                   verbose = FALSE, workdir = tmp)
+  code <- readLines(file.path(tmp, "src", "dust.cpp"))
+  expect_match(code, "internal.initial_time = 0;", fixed = TRUE, all = FALSE)
+})


### PR DESCRIPTION
This is basically impossible to test, because compiler warnings are really unportable.

At the moment though, this model produces a set of warnings, if you have things turned up noisy enough:

```r
odin.dust::odin_dust({
  initial(x) <- step + 1
  update(x) <- x
})
```

```
   g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I'/home/rich/lib/R/library/cpp11/include' -g -Wall -Wextra -pedantic -Wmaybe-uninitialized -Wno-unused-parameter -Wno-cast-function-type -Wno-missing-field-initializers -O2  -I/home/rich/lib/R/library/dust/include -DHAVE_INLINE -fopenmp -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-BNt0N4/r-base-4.2.2=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -c dust.cpp -o dust.o
   dust.cpp: In function ‘dust::pars_type<T> dust::dust_pars(cpp11::list) [with T = odin; cpp11::list = cpp11::r_vector<SEXPREC*>]’:
   dust.cpp:251:9: warning: typedef ‘using real_type = using real_type = double’ locally defined but not used [-Wunused-local-typedefs]
     251 |   using real_type = typename odin::real_type;
         |         ^~~~~~~~~
   dust.cpp: In function ‘cpp11::sexp dust::dust_info(const dust::pars_type<T>&) [with T = odin]’:
   dust.cpp:258:29: warning: variable ‘internal’ set but not used [-Wunused-but-set-variable]
     258 |   const odin::internal_type internal = pars.internal;
         |                             ^~~~~~~~
   In file included from /home/rich/lib/R/library/dust/include/dust/gpu/types.hpp:9,
                    from /home/rich/lib/R/library/dust/include/dust/gpu/launch_control.hpp:4,
                    from /home/rich/lib/R/library/dust/include/dust/gpu/device_resample.hpp:4,
                    from /home/rich/lib/R/library/dust/include/dust/gpu/dust_gpu.hpp:17,
                    from /home/rich/lib/R/library/dust/include/dust/r/dust.hpp:15,
                    from dust.cpp:1:
   /home/rich/lib/R/library/dust/include/dust/types.hpp: In function ‘dust::pars_type<T> dust::dust_pars(cpp11::list) [with T = odin; cpp11::list = cpp11::r_vector<SEXPREC*>]’:
   /home/rich/lib/R/library/dust/include/dust/types.hpp:22:40: warning: ‘internal.odin::internal_type::initial_x’ is used uninitialized in this function [-Wuninitialized]
      22 |     shared(shared_), internal(internal_) {
         |                                        ^
   dust.cpp:253:23: note: ‘internal.odin::internal_type::initial_x’ was declared here
     253 |   odin::internal_type internal;
         |                       ^~~~~~~~
```

With this PR it compiles cleanly with no warnings. The generated code is barely different:

```diff
diff --git a/prev/src/dust.cpp b/fixed/src/dust.cpp
index daae091..d0d4149 100644
--- a/prev/src/dust.cpp
+++ b/fixed/src/dust.cpp
@@ -248,14 +248,13 @@ inline cpp11::writable::integers integer_sequence(size_t from, size_t len) {
 namespace dust {
 template<>
 dust::pars_type<odin> dust_pars<odin>(cpp11::list user) {
-  using real_type = typename odin::real_type;
   auto shared = std::make_shared<odin::shared_type>();
   odin::internal_type internal;
+  internal.initial_x = 0;
   return dust::pars_type<odin>(shared, internal);
 }
 template <>
 cpp11::sexp dust_info<odin>(const dust::pars_type<odin>& pars) {
-  const odin::internal_type internal = pars.internal;
   const std::shared_ptr<const odin::shared_type> shared = pars.shared;
   cpp11::writable::strings nms({"x"});
   cpp11::writable::list dim(1);
```

This PR replaces #118, which was opened with the wrong branch name