### PR TITLE
mrc-3991: remove mode from odin.dust

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.2.30
+Version: 0.3.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),
@@ -21,8 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.12.9),
-    mode (>= 0.1.12),
+    dust (>= 0.13.1),
     odin (>= 1.3.5),
     tibble,
     vctrs
@@ -39,5 +38,4 @@ Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:
     mrc-ide/dust,
-    mrc-ide/mode,
     mrc-ide/odin

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -63,8 +63,7 @@ generate_dust <- function(ir, options) {
 
   continuous <- dat$features$continuous
   list(class = class, create = create, info = info, data = data, gpu = code_gpu,
-       support = support, include = include, name = dat$config$base,
-       continuous = continuous)
+       support = support, include = include, name = dat$config$base)
 }
 
 
@@ -485,6 +484,8 @@ generate_dust_core_attributes <- function(dat) {
   default <- vcapply(default_value, deparse_str)
 
   attr_class <- sprintf("// [[dust::class(%s)]]", dat$config$base)
+  time_type <- if (dat$features$continuous) "continuous" else "discrete"
+  attr_time <- sprintf("// [[dust::time_type(%s)]]", time_type)
 
   ## We need the param attribute in one line only, so some faffery
   ## required here:
@@ -494,7 +495,7 @@ generate_dust_core_attributes <- function(dat) {
     sprintf("rank = %d, min = %s, max = %s, integer = %s)]]",
             rank, min, max, integer))
 
-  c(attr_class, attr_param)
+  c(attr_class, attr_time, attr_param)
 }
 
 

--- a/R/odin_dust.R
+++ b/R/odin_dust.R
@@ -141,17 +141,12 @@ odin_dust_wrapper <- function(ir, srcdir, options) {
   path <- tempfile(fileext = ".cpp")
   writeLines(code, path)
 
-  if (dat$continuous) {
-    generator <- mode::mode(path,
-                            quiet = !options$verbose,
-                            workdir = options$workdir)
-  } else {
-    generator <- dust::dust(path, quiet = !options$verbose,
-                            workdir = options$workdir,
-                            gpu = options$gpu$compile,
-                            linking_to = linking_to,
-                            cpp_std = cpp_std)
-  }
+  generator <- dust::dust(path, quiet = !options$verbose,
+                          workdir = options$workdir,
+                          gpu = options$gpu$compile,
+                          linking_to = linking_to,
+                          cpp_std = cpp_std)
+
   if (!("transform_variables" %in% names(generator$public_methods))) {
     generator$set("public", "transform_variables",
                   odin_dust_transform_variables)


### PR DESCRIPTION
This PR updates odin.dust to use the continuous time support in dust, rather than mode. Not much required here - the only trick was remembering to add the attribute so that dust uses the right sort of support