### PR TITLE
Add support for print() debugging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:
     mrc-ide/dust,
-    mrc-ide/odin@mrc-3932
+    mrc-ide/odin

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),
@@ -22,7 +22,7 @@ Imports:
     cpp11,
     decor,
     dust (>= 0.13.1),
-    odin (>= 1.3.5),
+    odin (>= 1.4.5),
     tibble,
     vctrs
 Suggests:
@@ -38,4 +38,4 @@ Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:
     mrc-ide/dust,
-    mrc-ide/odin
+    mrc-ide/odin@mrc-3932

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# odin.dust 0.3.1
+
+* Support for odin's new `print()` based debugging
+
+# odin.dust 0.3.0
+
+* Complete support for continuous time models; these can contain both ODEs and discretely-timed stochastic updates (using recent dust)
+
 # odin.dust 0.2.24
 
 * Add support for `rgamma` and `rnbinom`, using new dust

--- a/R/utils.R
+++ b/R/utils.R
@@ -100,6 +100,11 @@ cpp_block <- function(body) {
 }
 
 
+cpp_when <- function(condition, body) {
+  c(sprintf("if (%s) {", condition), paste0("  ", body), "}")
+}
+
+
 cpp_namespace <- function(name, code) {
   c(sprintf("namespace %s {", name), code, "}")
 }


### PR DESCRIPTION
Requires https://github.com/mrc-ide/odin/pull/282 - update the branch pin before merge.

Fairly straightforward implementation here following the C one in odin, with one small wrinkle: we can't use `Rprintf` from multithreaded code! To get around this we can detect if we're running in parallel with `omp_in_parallel()` (this is true if we're in a block with more than one active thread), and then only evaluate _that_ function if OpenMP is available!