### PR TITLE
Make sure we behave properly with noninteger time

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.3.2
+Version: 0.3.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -78,7 +78,7 @@ generate_dust_meta <- function(options, continuous) {
        rng_state = "rng_state",
        rng_state_type = options$rng_state_type,
        real_type = options$real_type,
-       time_type = if (continuous) "real_type" else "step_t",
+       time_type = if (continuous) "real_type" else "size_t",
        update_stochastic_result = "state_next",
        internal_int = "internal_int",
        internal_real  = "internal_real",

--- a/tests/testthat/test-odin-dust.R
+++ b/tests/testthat/test-odin-dust.R
@@ -493,11 +493,32 @@ test_that("can compile deterministic model", {
   })
 
   mod <- gen$new(list(beta = 1), 1, 2)
-  mod$run(10)
+  y <- mod$run(10)
+  expect_equal(y, mod$state())
 
   expect_equal(mod$state()[1, ], c(10, 10))
   expect_equal(mod$state()[2, ], c(20, 20))
   expect_equal(mod$pars(), list(beta = 1))
+})
+
+
+test_that("can use noninteger time", {
+  gen <- odin_dust({
+    initial(x) <- 1
+    deriv(x) <- beta
+    output(y) <- x * 2
+
+    beta <- user(0)
+  })
+
+  mod <- gen$new(list(beta = 1), 1.2, 2)
+  y <- mod$run(10.5)
+  expect_equal(mod$time(), 10.5)
+  expect_equal(y[1, ], c(10.3, 10.3))
+  expect_equal(y[2, ], c(20.6, 20.6))
+  expect_equal(
+    mod$simulate(c(11.3, 12.8)),
+    array(c(11.1, 22.2, 11.1, 22.2, 12.6, 25.2, 12.6, 25.2), c(2, 2, 2)))
 })
 
 


### PR DESCRIPTION
This PR fixes the code generation error spotted in #126, where the ODE interface was using `size_t` where it should have used `real_type` sometimes. Not too bad I think