### PR TITLE
Fix multinomial example in porting vignette

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.3.6
+Version: 0.3.7
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),

--- a/vignettes/porting.Rmd
+++ b/vignettes/porting.Rmd
@@ -224,7 +224,7 @@ In the binomial case you can rewrite the multinomial sampling as a series of bin
 
 ```r
 y[1] <- rbinom(size, prob[1])
-y[2:length(y)] <- rbinom(size - sum(y[1:(i - 1)]), prob[i])
+y[2:length(y)] <- rbinom(size - sum(y[1:(i - 1)]), prob[i]/ sum(prob[i:length(y)]))
 ```
 
 A similar transform is possible for the multivariate hypergeometric from the hypergeometric (see [odin's `rmhyper` implementation for details](https://github.com/mrc-ide/odin/blob/f36738bb106e2f9289dbb2b94c67ffdb6cf5e0ed/inst/library.c#L358-L375)).

--- a/vignettes/porting.Rmd
+++ b/vignettes/porting.Rmd
@@ -224,7 +224,7 @@ In the binomial case you can rewrite the multinomial sampling as a series of bin
 
 ```r
 y[1] <- rbinom(size, prob[1])
-y[2:length(y)] <- rbinom(size - sum(y[1:(i - 1)]), prob[i]/ sum(prob[i:length(y)]))
+y[2:length(y)] <- rbinom(size - sum(y[1:(i - 1)]), prob[i] / sum(prob[i:length(y)]))
 ```
 
 A similar transform is possible for the multivariate hypergeometric from the hypergeometric (see [odin's `rmhyper` implementation for details](https://github.com/mrc-ide/odin/blob/f36738bb106e2f9289dbb2b94c67ffdb6cf5e0ed/inst/library.c#L358-L375)).


### PR DESCRIPTION
The example needs to account for having to renormalise probabilities (over the remaining possible outcomes) in the nested binomial draws