### PR TITLE
Support for interpolation

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,5 @@
 linters: linters_with_defaults(
+    indentation_linter = NULL,
     object_length_linter = NULL,
     object_usage_linter = NULL,
     cyclocomp_linter = NULL

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: odin.dust
 Title: Compile Odin to Dust
-Version: 0.3.8
+Version: 0.3.9
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Alex", "Hill", role = "aut"),
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.14.11),
+    dust (>= 0.15.1),
     odin (>= 1.5.0),
     tibble,
     vctrs
@@ -37,5 +37,5 @@ RoxygenNote: 7.2.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust@mrc-4581,
+    mrc-ide/dust,
     mrc-ide/odin

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     brio,
     cpp11,
     decor,
-    dust (>= 0.14.7),
+    dust (>= 0.14.11),
     odin (>= 1.5.0),
     tibble,
     vctrs
@@ -37,5 +37,5 @@ RoxygenNote: 7.2.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Remotes:
-    mrc-ide/dust,
+    mrc-ide/dust@mrc-4581,
     mrc-ide/odin

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -3,7 +3,8 @@ generate_dust <- function(ir, options) {
   features <- vlapply(dat$features, identity)
   supported <- c("initial_time_dependent", "has_user", "has_array", "has_debug",
                  "discrete", "has_stochastic", "has_include", "has_output",
-                 "continuous", "mixed", "has_data", "has_compare")
+                 "continuous", "mixed", "has_data", "has_compare",
+                 "has_interpolate")
   unsupported <- setdiff(names(features)[features], supported)
   if (length(unsupported) > 0L) {
     stop("Using unsupported features: ",
@@ -11,6 +12,9 @@ generate_dust <- function(ir, options) {
   }
   if (dat$features$has_output && !dat$features$continuous) {
     stop("Using unsupported features: 'has_output'")
+  }
+  if (dat$features$has_interpolate && !dat$features$continuous) {
+    stop("Using unsupported features: 'has_interpolate'")
   }
 
   ## There's no feature flag on "in place" expressions, though there
@@ -35,12 +39,15 @@ generate_dust <- function(ir, options) {
 
   include <- c(
     generate_dust_include(dat$config$include$data),
-    dat$compare_legacy$include)
+    dat$compare_legacy$include,
+    if (dat$features$has_interpolate)
+      "#include <dust/interpolate/interpolate.hpp>")
 
   used <- unique(unlist(lapply(dat$equations, function(x) {
     x$depends$functions
   }), FALSE, FALSE))
   support <- NULL
+
   if (any(c("sum", "odin_sum") %in% used)) {
     ranks <- sort(unique(viapply(dat$data$elements, "[[", "rank")))
     ranks <- ranks[ranks > 0]
@@ -127,8 +134,16 @@ generate_dust_core_class <- function(eqs, dat, rewrite) {
 
 generate_dust_core_struct <- function(dat) {
   struct_element <- function(x) {
+    is_interpolate <- x$storage_type == "interpolate_data"
+    if (is_interpolate) {
+      ## This is a bit unfortunate, we have to go digging here for
+      ## enough to be able to work out the order of interpolation:
+      x$storage_type <- sprintf("%s_%s",
+                                x$storage_type,
+                                dat$equations[[x$name]]$interpolate$type)
+    }
     type <- dust_type(x$storage_type)
-    is_ptr <- x$rank > 0L || type == "void"
+    is_ptr <- (x$rank > 0L || type == "void") && !is_interpolate # void imposs?
     if (is_ptr) {
       sprintf("  std::vector<%s> %s;", type, x$name)
     } else {

--- a/R/generate_dust.R
+++ b/R/generate_dust.R
@@ -143,7 +143,7 @@ generate_dust_core_struct <- function(dat) {
                                 dat$equations[[x$name]]$interpolate$type)
     }
     type <- dust_type(x$storage_type)
-    is_ptr <- (x$rank > 0L || type == "void") && !is_interpolate # void imposs?
+    is_ptr <- x$rank > 0L && !is_interpolate
     if (is_ptr) {
       sprintf("  std::vector<%s> %s;", type, x$name)
     } else {

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -249,7 +249,9 @@ generate_dust_equation_alloc_interpolate <- function(eq, data_info, dat,
                                                      rewrite, gpu) {
   data_info_target <- dat$data$elements[[eq$interpolate$equation]]
   if (data_info_target$rank != 0) {
-    stop("this won't work")
+    stop(paste("Can't yet interpolate vector valued variables",
+               sprintf("but tried to for '%s'.", data_info_target$name),
+               "Please let us know if you need this functionality"))
   }
 
   constructor <- switch(

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -263,7 +263,9 @@ generate_dust_equation_alloc_interpolate <- function(eq, data_info, dat,
   t <- rewrite(eq$interpolate$t)
   y <- rewrite(eq$interpolate$y)
 
-  sprintf("%s = %s<real_type>(%s, %s);", rewrite(eq$lhs), constructor, t, y)
+  sprintf('%s = %s<real_type>(%s, %s, "%s", "%s");',
+          rewrite(eq$lhs), constructor, t, y,
+          eq$interpolate$t, eq$interpolate$y)
 }
 
 

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -261,7 +261,7 @@ generate_dust_equation_alloc_interpolate <- function(eq, data_info, dat,
   t <- rewrite(eq$interpolate$t)
   y <- rewrite(eq$interpolate$y)
 
-  sprintf("%s = %s(%s, %s);", rewrite(eq$lhs), constructor, t, y)
+  sprintf("%s = %s<real_type>(%s, %s);", rewrite(eq$lhs), constructor, t, y)
 }
 
 

--- a/R/generate_dust_equation.R
+++ b/R/generate_dust_equation.R
@@ -256,7 +256,7 @@ generate_dust_equation_alloc_interpolate <- function(eq, data_info, dat,
     eq$interpolate$type,
     constant = "dust::interpolate::InterpolateConstant",
     linear = "dust::interpolate::InterpolateLinear",
-    stop(sprintf("%s interpolation not supported", eq$interpolate$type)))
+    spline = "dust::interpolate::InterpolateSpline")
 
   t <- rewrite(eq$interpolate$t)
   y <- rewrite(eq$interpolate$y)

--- a/R/utils.R
+++ b/R/utils.R
@@ -155,6 +155,8 @@ dust_type <- function(type) {
            "dust::interpolate::InterpolateConstant<real_type>",
          interpolate_data_linear =
            "dust::interpolate::InterpolateLinear<real_type>",
+         interpolate_data_spline =
+           "dust::interpolate::InterpolateSpline<real_type>",
          stop(sprintf("Unknown type '%s'", type)))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -151,6 +151,10 @@ dust_type <- function(type) {
   switch(type,
          double = "real_type",
          int = "int",
+         interpolate_data_constant =
+           "dust::interpolate::InterpolateConstant<real_type>",
+         interpolate_data_linear =
+           "dust::interpolate::InterpolateLinear<real_type>",
          stop(sprintf("Unknown type '%s'", type)))
 }
 

--- a/tests/testthat/test-interpolation.R
+++ b/tests/testthat/test-interpolation.R
@@ -81,3 +81,40 @@ test_that("spline", {
   expect_equal(yy[1, ], cmp, tolerance = 1e-5)
   expect_equal(yy[2, ], pulse(tt))
 })
+
+
+test_that("can't interpolate in discrete time models yet", {
+  expect_error(
+    odin_dust({
+      update(y) <- y + pulse
+      initial(y) <- 0
+      ##
+      pulse <- interpolate(tp, zp, "spline")
+      ##
+      tp[] <- user()
+      zp[] <- user()
+      dim(tp) <- user()
+      dim(zp) <- user()
+    }),
+    "Using unsupported features: 'has_interpolate'")
+})
+
+
+test_that("can't interpolate with vector output", {
+  expect_error(
+    odin_dust({
+      deriv(y[]) <- pulse[i]
+      initial(y[]) <- 0
+      ##
+      pulse[] <- interpolate(tp, zp, "constant")
+      ##
+      tp[] <- user()
+      zp[, ] <- user()
+      dim(tp) <- user()
+      dim(zp) <- user()
+      dim(pulse) <- 2
+      dim(y) <- 2
+    }),
+    "Can't yet interpolate vector valued variables but tried to for 'pulse'.",
+    fixed = TRUE)
+})

--- a/tests/testthat/test-interpolation.R
+++ b/tests/testthat/test-interpolation.R
@@ -1,0 +1,52 @@
+test_that("constant", {
+  gen <- odin_dust({
+    deriv(y) <- pulse
+    initial(y) <- 0
+    ##
+    pulse <- interpolate(tp, zp, "constant")
+    ##
+    tp[] <- user()
+    zp[] <- user()
+    dim(tp) <- user()
+    dim(zp) <- user()
+    output(p) <- pulse
+  })
+
+  tp <- c(0, 1, 2)
+  zp <- c(0, 1, 0)
+  mod <- gen$new(list(tp = tp, zp = zp), 0, 1)
+  tt <- seq(0, 3, length.out = 301)
+  yy <- drop(mod$simulate(tt))
+
+  zz <- ifelse(tt < 1, 0, ifelse(tt > 2, 1, tt - 1))
+  expect_equal(yy[1, ], zz, tolerance = 1e-5)
+  expect_equal(yy[2, ], approx(tp, zp, tt, "constant", rule = 2)$y)
+})
+
+
+test_that("linear", {
+  gen <- odin_dust({
+    deriv(y) <- pulse
+    initial(y) <- 0
+    ##
+    pulse <- interpolate(tp, zp, "linear")
+    ##
+    tp[] <- user()
+    zp[] <- user()
+    dim(tp) <- user()
+    dim(zp) <- user()
+    output(p) <- pulse
+  })
+
+  tp <- c(0, 1, 2)
+  zp <- c(0, 1, 0)
+  mod <- gen$new(list(tp = tp, zp = zp), 0, 1)
+  tt <- seq(0, 2, length.out = 101)
+  yy <- drop(mod$simulate(tt))
+
+  expect_equal(yy[2, ], approx(tp, zp, tt, "linear")$y)
+
+  pulse <- approxfun(tp, zp, "linear")
+  target <- function(t, x, .) pulse(t)
+  expect_equal(yy[1, ], dde::dopri(0, tt, target, NULL)[, 2], tolerance = 1e-5)
+})

--- a/tests/testthat/test-interpolation.R
+++ b/tests/testthat/test-interpolation.R
@@ -53,7 +53,7 @@ test_that("linear", {
 })
 
 
-test_that_odin("spline", {
+test_that("spline", {
   gen <- odin_dust({
     deriv(y) <- pulse
     initial(y) <- 0

--- a/tests/testthat/test-interpolation.R
+++ b/tests/testthat/test-interpolation.R
@@ -21,6 +21,12 @@ test_that("constant", {
   zz <- ifelse(tt < 1, 0, ifelse(tt > 2, 1, tt - 1))
   expect_equal(yy[1, ], zz, tolerance = 1e-5)
   expect_equal(yy[2, ], approx(tp, zp, tt, "constant", rule = 2)$y)
+
+  expect_error(
+    gen$new(list(tp = tp, zp = 1), 0, 1),
+    paste("Time variable 'tp' and interpolation target 'zp'",
+          "must have the same length, but do not (3 vs 1)"),
+    fixed = TRUE)
 })
 
 

--- a/vignettes/porting.Rmd
+++ b/vignettes/porting.Rmd
@@ -79,13 +79,11 @@ t(drop(gen$new(list(), 0, 1)$simulate(0:5)))
 
 Here, the first column is `x` as in the first column. The second column computes the relationship with the `x` at the beginning of the time step, while the third is most equivalent to our previous `output` command and requires storing the that will become the updated `x` in order to use that value to both update `x` and `y2`.
 
-## Avoiding `interpolate()`
+## Limited support for `interpolate()`
 
-*We may support this in future for ODE models, but are undecided as to if this makes sense for discrete-time models.*
+This is supported for ODE models, though only for interpolating scalar outputs (this was by far the most common use case).
 
-For ODE models, unfortunately there's nothing you can do at present. Get in touch if this is a limitation that you would like to overcome as we will need to implement support both in this package and in `mode`.
-
-For discrete-time models we recommend doing the interpolation as part of your parameter preparation and passing in an expanded vector which you then look up. This also makes it (somewhat) more obvious how time is being treated in your model.
+Interpolation is not supported for discrete time models.  For these models, we recommend doing the interpolation as part of your parameter preparation and passing in an expanded vector which you then look up. This also makes it (somewhat) more obvious how time is being treated in your model.
 
 For an example, here's a model of logistic growth in discrete time, where the carrying capacity varies seasonally, implemented as a piecewise-constant interpolation between some points.  It's easy enough to create some sort of time varying time series to use:
 


### PR DESCRIPTION
Uses https://github.com/mrc-ide/dust/pull/415 so merge that first and update the branch pin.

This PR allows for basic interpolation, subject to some conditions:

* ~only piecewise constant and linear is supported~
* the interpolated y must be a scalar (i.e. no multivariable targets supported yet)
* does not work in discrete time models